### PR TITLE
feat: upgrade typescript client

### DIFF
--- a/components/client/typescript/package-lock.json
+++ b/components/client/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hirosystems/chainhook-client",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hirosystems/chainhook-client",
-      "version": "1.0.4",
+      "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
         "@fastify/type-provider-typebox": "^3.0.0",

--- a/components/client/typescript/package.json
+++ b/components/client/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hirosystems/chainhook-client",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "Chainhook TypeScript client",
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",

--- a/components/client/typescript/src/schemas/bitcoin/payload.ts
+++ b/components/client/typescript/src/schemas/bitcoin/payload.ts
@@ -46,7 +46,7 @@ export const BitcoinCursedInscriptionRevealedSchema = Type.Object({
   ordinal_block_height: Type.Integer(),
   ordinal_offset: Type.Integer(),
   satpoint_post_inscription: Type.String(),
-  curse_type: Type.String(),
+  curse_type: Nullable(Type.Union([Type.String(), Type.Object({ tag: Type.Number() })])),
 });
 export type BitcoinCursedInscriptionRevealed = Static<
   typeof BitcoinCursedInscriptionRevealedSchema

--- a/components/client/typescript/src/server.ts
+++ b/components/client/typescript/src/server.ts
@@ -179,11 +179,11 @@ export async function buildServer(
       async (request, reply) => {
         try {
           await callback(request.params.uuid, request.body);
+          await reply.code(200).send();
         } catch (error) {
           logger.error(error, `ChainhookEventObserver error processing payload`);
-          await reply.code(422).send();
+          await reply.code(500).send();
         }
-        await reply.code(200).send();
       }
     );
     done();


### PR DESCRIPTION
* Send HTTP 500 response on payload errors so node can retry
* Fix `curse_type` schema to include null and tagged objects
* Add `wait_for_chainhook_node` option to be able to skip server pings on local chainhook tests