### PR TITLE
feat: update inscription transfer schemas

### DIFF
--- a/components/client/typescript/package-lock.json
+++ b/components/client/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hirosystems/chainhook-client",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hirosystems/chainhook-client",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "ISC",
       "dependencies": {
         "@fastify/type-provider-typebox": "^3.0.0",

--- a/components/client/typescript/package-lock.json
+++ b/components/client/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hirosystems/chainhook-client",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hirosystems/chainhook-client",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "license": "ISC",
       "dependencies": {
         "@fastify/type-provider-typebox": "^3.0.0",

--- a/components/client/typescript/package-lock.json
+++ b/components/client/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hirosystems/chainhook-client",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hirosystems/chainhook-client",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "ISC",
       "dependencies": {
         "@fastify/type-provider-typebox": "^3.0.0",

--- a/components/client/typescript/package.json
+++ b/components/client/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hirosystems/chainhook-client",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Chainhook TypeScript client",
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",

--- a/components/client/typescript/package.json
+++ b/components/client/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hirosystems/chainhook-client",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Chainhook TypeScript client",
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",

--- a/components/client/typescript/package.json
+++ b/components/client/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hirosystems/chainhook-client",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Chainhook TypeScript client",
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",

--- a/components/client/typescript/src/schemas/bitcoin/payload.ts
+++ b/components/client/typescript/src/schemas/bitcoin/payload.ts
@@ -23,9 +23,7 @@ export const BitcoinInscriptionRevealedSchema = Type.Object({
 export type BitcoinInscriptionRevealed = Static<typeof BitcoinInscriptionRevealedSchema>;
 
 export const BitcoinInscriptionTransferredSchema = Type.Object({
-  inscription_number: Type.Integer(),
   inscription_id: Type.String(),
-  ordinal_number: Type.Integer(),
   updated_address: Nullable(Type.String()),
   satpoint_pre_transfer: Type.String(),
   satpoint_post_transfer: Type.String(),

--- a/components/client/typescript/src/schemas/payload.ts
+++ b/components/client/typescript/src/schemas/payload.ts
@@ -12,6 +12,7 @@ export const PayloadSchema = Type.Object({
   chainhook: Type.Object({
     uuid: Type.String(),
     predicate: Type.Union([BitcoinIfThisSchema, StacksIfThisSchema]),
+    is_streaming_blocks: Type.Boolean(),
   }),
 });
 export type Payload = Static<typeof PayloadSchema>;


### PR DESCRIPTION
* Remove `inscription_number` and `ordinal_number` from inscription transfers
* Add option to validate chainhook payload schemas
* Add option to set a custom body size limit