### PR TITLE
fix: coinbase tx sats_in < sats_out

### DIFF
--- a/components/chainhook-sdk/src/indexer/bitcoin/mod.rs
+++ b/components/chainhook-sdk/src/indexer/bitcoin/mod.rs
@@ -425,6 +425,13 @@ pub fn standardize_bitcoin_block(
             });
         }
 
+        // only coinbase transaction have no inputs
+        let fee = if sats_in < sats_out {
+            0
+        } else {
+            sats_in - sats_out
+        };
+
         let tx = BitcoinTransactionData {
             transaction_identifier: TransactionIdentifier {
                 hash: format!("0x{}", txid),
@@ -436,7 +443,7 @@ pub fn standardize_bitcoin_block(
                 stacks_operations,
                 ordinal_operations: vec![],
                 proof: None,
-                fee: sats_in - sats_out,
+                fee,
             },
         };
         transactions.push(tx);


### PR DESCRIPTION
### Description

In my local regtest test environment, I found that condition: `sats_in < sats_out`. The reason is that current block is only coinbase transaction , it have no other inputs, so sats_in is 0 and sats_out > 0

### Checklist

- [x] All tests pass
- [x] Tests added in this PR (if applicable)