### PR TITLE
fix: make contract_identifier and contains optional

### DIFF
--- a/components/client/typescript/package-lock.json
+++ b/components/client/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hirosystems/chainhook-client",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hirosystems/chainhook-client",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "license": "Apache 2.0",
       "dependencies": {
         "@fastify/type-provider-typebox": "^3.2.0",

--- a/components/client/typescript/package.json
+++ b/components/client/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hirosystems/chainhook-client",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Chainhook TypeScript client",
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",

--- a/components/client/typescript/src/schemas/stacks/if_this.ts
+++ b/components/client/typescript/src/schemas/stacks/if_this.ts
@@ -48,8 +48,8 @@ export type StacksIfThisStxEvent = Static<typeof StacksIfThisStxEventSchema>;
 
 export const StacksIfThisPrintEventSchema = Type.Object({
   scope: Type.Literal('print_event'),
-  contract_identifier: Type.String(),
-  contains: Type.String(),
+  contract_identifier: Type.Optional(Type.String()),
+  contains: Type.Optional(Type.String()),
 });
 export type StacksIfThisPrintEvent = Static<typeof StacksIfThisPrintEventSchema>;
 


### PR DESCRIPTION
### Description

Make `contract_identifier` and `contains` values optional for `print_event` predicates in the TS client.

---

### Checklist

- [ ] All tests pass
- [ ] Tests added in this PR (if applicable)

