### PR TITLE
Quick tweaks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,7 +416,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chainhook"
-version = "0.20.0"
+version = "1.0.0"
 dependencies = [
  "ansi_term",
  "atty",
@@ -457,13 +457,13 @@ dependencies = [
 
 [[package]]
 name = "chainhook-sdk"
-version = "0.8.0"
+version = "0.8.2"
 dependencies = [
  "base58 0.2.0",
  "base64",
  "bitcoincore-rpc",
  "bitcoincore-rpc-json",
- "chainhook-types 1.0.9",
+ "chainhook-types 1.0.11",
  "clarinet-utils",
  "crossbeam-channel 0.5.8",
  "dashmap 5.4.0",
@@ -504,7 +504,7 @@ dependencies = [
 
 [[package]]
 name = "chainhook-types"
-version = "1.0.9"
+version = "1.0.11"
 dependencies = [
  "hex",
  "schemars 0.8.12",

--- a/components/chainhook-cli/Cargo.toml
+++ b/components/chainhook-cli/Cargo.toml
@@ -15,7 +15,7 @@ redis = "0.21.5"
 serde-redis = "0.12.0"
 hex = "0.4.3"
 rand = "0.8.5"
-chainhook-sdk = { version = "0.8.3", default-features = false, features = ["zeromq"], path = "../chainhook-sdk" }
+chainhook-sdk = { version = "0.8.2", default-features = false, features = ["zeromq"], path = "../chainhook-sdk" }
 clarinet-files = "1.0.1"
 hiro-system-kit = "0.1.0"
 # clarinet-files = { path = "../../../clarinet/components/clarinet-files" }

--- a/components/chainhook-cli/Cargo.toml
+++ b/components/chainhook-cli/Cargo.toml
@@ -17,7 +17,7 @@ hex = "0.4.3"
 rand = "0.8.5"
 # tikv-client = { git = "https://github.com/tikv/client-rust.git", rev = "8f54e6114227718e256027df2577bbacdf425f86" }
 # raft-proto = { git = "https://github.com/tikv/raft-rs", rev="f73766712a538c2f6eb135b455297ad6c03fc58d", version = "0.7.0"}
-chainhook-sdk = { version = "0.8.0", default-features = false, features = ["zeromq"], path = "../chainhook-sdk" }
+chainhook-sdk = { version = "0.8.1", default-features = false, features = ["zeromq"], path = "../chainhook-sdk" }
 clarinet-files = "1.0.1"
 hiro-system-kit = "0.1.0"
 # clarinet-files = { path = "../../../clarinet/components/clarinet-files" }

--- a/components/chainhook-cli/Cargo.toml
+++ b/components/chainhook-cli/Cargo.toml
@@ -15,9 +15,7 @@ redis = "0.21.5"
 serde-redis = "0.12.0"
 hex = "0.4.3"
 rand = "0.8.5"
-# tikv-client = { git = "https://github.com/tikv/client-rust.git", rev = "8f54e6114227718e256027df2577bbacdf425f86" }
-# raft-proto = { git = "https://github.com/tikv/raft-rs", rev="f73766712a538c2f6eb135b455297ad6c03fc58d", version = "0.7.0"}
-chainhook-sdk = { version = "0.8.1", default-features = false, features = ["zeromq"], path = "../chainhook-sdk" }
+chainhook-sdk = { version = "0.8.3", default-features = false, features = ["zeromq"], path = "../chainhook-sdk" }
 clarinet-files = "1.0.1"
 hiro-system-kit = "0.1.0"
 # clarinet-files = { path = "../../../clarinet/components/clarinet-files" }

--- a/components/chainhook-cli/src/scan/bitcoin.rs
+++ b/components/chainhook-cli/src/scan/bitcoin.rs
@@ -219,7 +219,7 @@ pub async fn execute_predicates_action<'a>(
                 actions_triggered += 1;
                 match action {
                     BitcoinChainhookOccurrence::Http(request) => {
-                        send_request(request, 10, 3, &ctx).await
+                        send_request(request, 10, 3, &ctx).await?
                     }
                     BitcoinChainhookOccurrence::File(path, bytes) => {
                         file_append(path, bytes, &ctx)?

--- a/components/chainhook-cli/src/scan/bitcoin.rs
+++ b/components/chainhook-cli/src/scan/bitcoin.rs
@@ -219,7 +219,7 @@ pub async fn execute_predicates_action<'a>(
                 actions_triggered += 1;
                 match action {
                     BitcoinChainhookOccurrence::Http(request) => {
-                        send_request(request, 3, 1, &ctx).await?
+                        send_request(request, 10, 3, &ctx).await
                     }
                     BitcoinChainhookOccurrence::File(path, bytes) => {
                         file_append(path, bytes, &ctx)?

--- a/components/chainhook-cli/src/scan/stacks.rs
+++ b/components/chainhook-cli/src/scan/stacks.rs
@@ -392,7 +392,7 @@ pub async fn scan_stacks_chainstate_via_csv_using_predicate(
                 occurrences_found += 1;
                 let res = match action {
                     StacksChainhookOccurrence::Http(request) => {
-                        send_request(request, 3, 1, &ctx).await
+                        send_request(request, 10, 3, &ctx).await
                     }
                     StacksChainhookOccurrence::File(path, bytes) => file_append(path, bytes, &ctx),
                     StacksChainhookOccurrence::Data(_payload) => unreachable!(),

--- a/components/chainhook-cli/src/service/runloops.rs
+++ b/components/chainhook-cli/src/service/runloops.rs
@@ -57,7 +57,7 @@ pub fn start_stacks_scan_runloop(
             let last_block_scanned = match res {
                 Ok(last_block_scanned) => last_block_scanned,
                 Err(e) => {
-                    error!(
+                    warn!(
                         moved_ctx.expect_logger(),
                         "Unable to evaluate predicate on Stacks chainstate: {e}",
                     );

--- a/components/chainhook-sdk/Cargo.toml
+++ b/components/chainhook-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chainhook-sdk"
-version = "0.8.0"
+version = "0.8.1"
 description = "Stateless Transaction Indexing Engine for Stacks and Bitcoin"
 license = "GPL-3.0"
 edition = "2021"
@@ -18,7 +18,7 @@ hiro-system-kit = "0.1.0"
 # stacks-rpc-client = { version = "1", path = "../../../clarinet/components/stacks-rpc-client" }
 # clarinet-utils = { version = "1", path = "../../../clarinet/components/clarinet-utils" }
 # hiro-system-kit = { version = "0.1.0", path = "../../../clarinet/components/hiro-system-kit" }
-chainhook-types = { version = "1.0.9", path = "../chainhook-types-rs" }
+chainhook-types = { version = "1.0.10", path = "../chainhook-types-rs" }
 rocket = { version = "=0.5.0-rc.3", features = ["json"] }
 bitcoincore-rpc = "0.16.0"
 bitcoincore-rpc-json = "0.16.0"

--- a/components/chainhook-sdk/Cargo.toml
+++ b/components/chainhook-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chainhook-sdk"
-version = "0.8.1"
+version = "0.8.2"
 description = "Stateless Transaction Indexing Engine for Stacks and Bitcoin"
 license = "GPL-3.0"
 edition = "2021"
@@ -18,7 +18,7 @@ hiro-system-kit = "0.1.0"
 # stacks-rpc-client = { version = "1", path = "../../../clarinet/components/stacks-rpc-client" }
 # clarinet-utils = { version = "1", path = "../../../clarinet/components/clarinet-utils" }
 # hiro-system-kit = { version = "0.1.0", path = "../../../clarinet/components/hiro-system-kit" }
-chainhook-types = { version = "1.0.10", path = "../chainhook-types-rs" }
+chainhook-types = { version = "1.0.11", path = "../chainhook-types-rs" }
 rocket = { version = "=0.5.0-rc.3", features = ["json"] }
 bitcoincore-rpc = "0.16.0"
 bitcoincore-rpc-json = "0.16.0"

--- a/components/chainhook-sdk/src/chainhooks/bitcoin/mod.rs
+++ b/components/chainhook-sdk/src/chainhooks/bitcoin/mod.rs
@@ -423,7 +423,6 @@ impl BitcoinPredicateType {
                 for op in tx.metadata.ordinal_operations.iter() {
                     match op {
                         OrdinalOperation::InscriptionRevealed(_)
-                        | OrdinalOperation::CursedInscriptionRevealed(_)
                         | OrdinalOperation::InscriptionTransferred(_) => return true,
                     }
                 }

--- a/components/chainhook-sdk/src/chainhooks/tests/mod.rs
+++ b/components/chainhook-sdk/src/chainhooks/tests/mod.rs
@@ -3,15 +3,29 @@ use std::collections::HashMap;
 use self::fixtures::get_all_event_types;
 
 use super::{
-    stacks::{evaluate_stacks_chainhooks_on_chain_event, StacksTriggerChainhook, handle_stacks_hook_action, StacksChainhookOccurrence},
-    types::{StacksChainhookSpecification, StacksPrintEventBasedPredicate, StacksNftEventBasedPredicate, StacksFtEventBasedPredicate,StacksContractCallBasedPredicate,StacksContractDeploymentPredicate, ExactMatchingRule, FileHook, StacksTrait},
+    stacks::{
+        evaluate_stacks_chainhooks_on_chain_event, handle_stacks_hook_action,
+        StacksChainhookOccurrence, StacksTriggerChainhook,
+    },
+    types::{
+        ExactMatchingRule, FileHook, StacksChainhookSpecification,
+        StacksContractCallBasedPredicate, StacksContractDeploymentPredicate,
+        StacksFtEventBasedPredicate, StacksNftEventBasedPredicate, StacksPrintEventBasedPredicate,
+        StacksTrait,
+    },
 };
-use crate::{chainhooks::{types::{HookAction, StacksPredicate, StacksStxEventBasedPredicate,}, tests::fixtures::{get_expected_occurrence, get_test_event_by_type}}, utils::AbstractStacksBlock};
 use crate::utils::Context;
-use chainhook_types::{StacksNetwork, StacksTransactionEvent, StacksTransactionData};
+use crate::{
+    chainhooks::{
+        tests::fixtures::{get_expected_occurrence, get_test_event_by_type},
+        types::{HookAction, StacksPredicate, StacksStxEventBasedPredicate},
+    },
+    utils::AbstractStacksBlock,
+};
 use chainhook_types::{StacksBlockUpdate, StacksChainEvent, StacksChainUpdatedWithBlocksData};
-use test_case::test_case;
+use chainhook_types::{StacksNetwork, StacksTransactionData, StacksTransactionEvent};
 use serde_json::Value as JsonValue;
+use test_case::test_case;
 
 pub mod fixtures;
 
@@ -88,7 +102,6 @@ pub mod fixtures;
     0;
     "FtEvent predicates don't match if missing event"
 )]
-
 // NftEvent predicate tests
 #[test_case(
     vec![vec![get_test_event_by_type("nft_mint")]], 
@@ -211,7 +224,6 @@ pub mod fixtures;
     0;
     "StxEvent predicates don't match if missing event"
 )]
-
 // PrintEvent predicate tests
 #[test_case(
     vec![vec![get_test_event_by_type("smart_contract_print_event")]], 
@@ -236,17 +248,17 @@ pub mod fixtures;
     StacksPredicate::PrintEvent(StacksPrintEventBasedPredicate {
         contract_identifier: "wront-id".to_string(),
         contains: "some-value".to_string(),
-    }), 
+    }),
     0;
     "PrintEvent predicate rejects non matching contract_identifier"
 )]
 #[test_case(
     vec![vec![get_test_event_by_type("smart_contract_print_event")]], 
     StacksPredicate::PrintEvent(StacksPrintEventBasedPredicate {
-        contract_identifier: 
+        contract_identifier:
             "ST3AXH4EBHD63FCFPTZ8GR29TNTVWDYPGY0KDY5E5.loan-data".to_string(),
         contains: "wrong-value".to_string(),
-    }), 
+    }),
     0;
     "PrintEvent predicate rejects non matching contains value"
 )]
@@ -255,7 +267,7 @@ pub mod fixtures;
     StacksPredicate::PrintEvent(StacksPrintEventBasedPredicate {
         contract_identifier: "*".to_string(),
         contains: "some-value".to_string(),
-    }), 
+    }),
     1;
     "PrintEvent predicate contract_identifier wildcard checks all print events for match"
 )]
@@ -264,7 +276,7 @@ pub mod fixtures;
     StacksPredicate::PrintEvent(StacksPrintEventBasedPredicate {
         contract_identifier: "ST3AXH4EBHD63FCFPTZ8GR29TNTVWDYPGY0KDY5E5.loan-data".to_string(),
         contains: "*".to_string(),
-    }), 
+    }),
     1;
     "PrintEvent predicate contains wildcard matches all values for matching events"
 )]
@@ -273,17 +285,24 @@ pub mod fixtures;
     StacksPredicate::PrintEvent(StacksPrintEventBasedPredicate {
         contract_identifier: "*".to_string(),
         contains: "*".to_string(),
-    }), 
+    }),
     2;
     "PrintEvent predicate contract_identifier wildcard and contains wildcard matches all values on all print events"
 )]
-fn test_stacks_predicates(blocks_with_events: Vec<Vec<StacksTransactionEvent>>, predicate: StacksPredicate, expected_applies: u64) {
+fn test_stacks_predicates(
+    blocks_with_events: Vec<Vec<StacksTransactionEvent>>,
+    predicate: StacksPredicate,
+    expected_applies: u64,
+) {
     // Prepare block
-    let new_blocks = blocks_with_events.iter().map(|events| StacksBlockUpdate {
-        block: fixtures::build_stacks_testnet_block_from_smart_contract_event_data(events),
-        parent_microblocks_to_apply: vec![],
-        parent_microblocks_to_rollback: vec![],
-    }).collect();
+    let new_blocks = blocks_with_events
+        .iter()
+        .map(|events| StacksBlockUpdate {
+            block: fixtures::build_stacks_testnet_block_from_smart_contract_event_data(events),
+            parent_microblocks_to_apply: vec![],
+            parent_microblocks_to_rollback: vec![],
+        })
+        .collect();
     let event = StacksChainEvent::ChainUpdatedWithBlocks(StacksChainUpdatedWithBlocksData {
         new_blocks,
         confirmed_blocks: vec![],
@@ -312,13 +331,11 @@ fn test_stacks_predicates(blocks_with_events: Vec<Vec<StacksTransactionEvent>>, 
 
     if expected_applies == 0 {
         assert_eq!(triggered.len(), 0)
-    }
-    else {
+    } else {
         let actual_applies: u64 = triggered[0].apply.len().try_into().unwrap();
         assert_eq!(actual_applies, expected_applies);
     }
 }
-
 
 #[test_case(
     StacksPredicate::ContractDeployment(StacksContractDeploymentPredicate::Deployer("ST13F481SBR0R7Z6NMMH8YV2FJJYXA5JPA0AD3HP9".to_string())), 
@@ -326,41 +343,44 @@ fn test_stacks_predicates(blocks_with_events: Vec<Vec<StacksTransactionEvent>>, 
     "Deployer predicate matches by contract deployer"
 )]
 #[test_case(
-    StacksPredicate::ContractDeployment(StacksContractDeploymentPredicate::Deployer("*".to_string())), 
+    StacksPredicate::ContractDeployment(StacksContractDeploymentPredicate::Deployer("*".to_string())),
     1;
     "Deployer predicate wildcard deployer catches all occurences"
 )]
 #[test_case(
-    StacksPredicate::ContractDeployment(StacksContractDeploymentPredicate::Deployer("wrong-deployer".to_string())), 
+    StacksPredicate::ContractDeployment(StacksContractDeploymentPredicate::Deployer("wrong-deployer".to_string())),
     0;
     "Deployer predicate does not match non-matching deployer"
 )]
 #[test_case(
-    StacksPredicate::ContractDeployment(StacksContractDeploymentPredicate::ImplementTrait(StacksTrait::Sip09)), 
+    StacksPredicate::ContractDeployment(StacksContractDeploymentPredicate::ImplementTrait(StacksTrait::Sip09)),
     0;
     "ImplementSip predicate returns no values for Sip09"
 )]
 #[test_case(
-    StacksPredicate::ContractDeployment(StacksContractDeploymentPredicate::ImplementTrait(StacksTrait::Sip10)), 
+    StacksPredicate::ContractDeployment(StacksContractDeploymentPredicate::ImplementTrait(StacksTrait::Sip10)),
     0;
     "ImplementSip predicate returns no values for Sip10"
 )]
 #[test_case(
-    StacksPredicate::ContractDeployment(StacksContractDeploymentPredicate::ImplementTrait(StacksTrait::Any)), 
+    StacksPredicate::ContractDeployment(StacksContractDeploymentPredicate::ImplementTrait(StacksTrait::Any)),
     0;
     "ImplementSip predicate returns no values for Any"
 )]
 fn test_stacks_predicate_contract_deploy(predicate: StacksPredicate, expected_applies: u64) {
     // Prepare block
-    let new_blocks = vec![StacksBlockUpdate {
-        block: fixtures::build_stacks_testnet_block_with_contract_deployment(),
-        parent_microblocks_to_apply: vec![],
-        parent_microblocks_to_rollback: vec![],
-    }, StacksBlockUpdate {
-        block: fixtures::build_stacks_testnet_block_with_contract_call(),
-        parent_microblocks_to_apply: vec![],
-        parent_microblocks_to_rollback: vec![],
-    }];
+    let new_blocks = vec![
+        StacksBlockUpdate {
+            block: fixtures::build_stacks_testnet_block_with_contract_deployment(),
+            parent_microblocks_to_apply: vec![],
+            parent_microblocks_to_rollback: vec![],
+        },
+        StacksBlockUpdate {
+            block: fixtures::build_stacks_testnet_block_with_contract_call(),
+            parent_microblocks_to_apply: vec![],
+            parent_microblocks_to_rollback: vec![],
+        },
+    ];
     let event = StacksChainEvent::ChainUpdatedWithBlocks(StacksChainUpdatedWithBlocksData {
         new_blocks,
         confirmed_blocks: vec![],
@@ -389,11 +409,9 @@ fn test_stacks_predicate_contract_deploy(predicate: StacksPredicate, expected_ap
 
     if expected_applies == 0 {
         assert_eq!(triggered.len(), 0)
-    }
-    else if triggered.len() == 0 {
+    } else if triggered.len() == 0 {
         panic!("expected more than one block to be applied, but no predicates were triggered")
-    }
-    else {
+    } else {
         let actual_applies: u64 = triggered[0].apply.len().try_into().unwrap();
         assert_eq!(actual_applies, expected_applies);
     }
@@ -403,7 +421,7 @@ fn test_stacks_predicate_contract_deploy(predicate: StacksPredicate, expected_ap
     StacksPredicate::ContractCall(StacksContractCallBasedPredicate {
         contract_identifier: "ST13F481SBR0R7Z6NMMH8YV2FJJYXA5JPA0AD3HP9.subnet-v1".to_string(),
         method: "commit-block".to_string()
-    }), 
+    }),
     1;
     "ContractCall predicate matches by contract identifier and method"
 )]
@@ -411,7 +429,7 @@ fn test_stacks_predicate_contract_deploy(predicate: StacksPredicate, expected_ap
     StacksPredicate::ContractCall(StacksContractCallBasedPredicate {
         contract_identifier: "ST13F481SBR0R7Z6NMMH8YV2FJJYXA5JPA0AD3HP9.subnet-v1".to_string(),
         method: "wrong-method".to_string()
-    }), 
+    }),
     0;
     "ContractCall predicate does not match for wrong method"
 )]
@@ -419,7 +437,7 @@ fn test_stacks_predicate_contract_deploy(predicate: StacksPredicate, expected_ap
     StacksPredicate::ContractCall(StacksContractCallBasedPredicate {
         contract_identifier: "wrong-id".to_string(),
         method: "commit-block".to_string()
-    }), 
+    }),
     0;
     "ContractCall predicate does not match for wrong contract identifier"
 )]
@@ -435,15 +453,18 @@ fn test_stacks_predicate_contract_deploy(predicate: StacksPredicate, expected_ap
 )]
 fn test_stacks_predicate_contract_call(predicate: StacksPredicate, expected_applies: u64) {
     // Prepare block
-    let new_blocks = vec![StacksBlockUpdate {
-        block: fixtures::build_stacks_testnet_block_with_contract_call(),
-        parent_microblocks_to_apply: vec![],
-        parent_microblocks_to_rollback: vec![],
-    },StacksBlockUpdate {
-        block: fixtures::build_stacks_testnet_block_with_contract_deployment(),
-        parent_microblocks_to_apply: vec![],
-        parent_microblocks_to_rollback: vec![],
-    }];
+    let new_blocks = vec![
+        StacksBlockUpdate {
+            block: fixtures::build_stacks_testnet_block_with_contract_call(),
+            parent_microblocks_to_apply: vec![],
+            parent_microblocks_to_rollback: vec![],
+        },
+        StacksBlockUpdate {
+            block: fixtures::build_stacks_testnet_block_with_contract_deployment(),
+            parent_microblocks_to_apply: vec![],
+            parent_microblocks_to_rollback: vec![],
+        },
+    ];
     let event = StacksChainEvent::ChainUpdatedWithBlocks(StacksChainUpdatedWithBlocksData {
         new_blocks,
         confirmed_blocks: vec![],
@@ -472,11 +493,9 @@ fn test_stacks_predicate_contract_call(predicate: StacksPredicate, expected_appl
 
     if expected_applies == 0 {
         assert_eq!(triggered.len(), 0)
-    }
-    else if triggered.len() == 0 {
+    } else if triggered.len() == 0 {
         panic!("expected more than one block to be applied, but no predicates were triggered")
-    }
-    else {
+    } else {
         let actual_applies: u64 = triggered[0].apply.len().try_into().unwrap();
         assert_eq!(actual_applies, expected_applies);
     }
@@ -496,39 +515,47 @@ fn test_stacks_hook_action_noop() {
         expire_after_occurrence: None,
         capture_all_events: None,
         decode_clarity_values: None,
-        predicate: StacksPredicate::Txid(ExactMatchingRule::Equals("0xb92c2ade84a8b85f4c72170680ae42e65438aea4db72ba4b2d6a6960f4141ce8".to_string())),
+        predicate: StacksPredicate::Txid(ExactMatchingRule::Equals(
+            "0xb92c2ade84a8b85f4c72170680ae42e65438aea4db72ba4b2d6a6960f4141ce8".to_string(),
+        )),
         action: HookAction::Noop,
         enabled: true,
     };
 
-
     let apply_block_data = fixtures::build_stacks_testnet_block_with_contract_call();
-    let apply_transactions = apply_block_data.transactions.iter().map(|t|t).collect();
+    let apply_transactions = apply_block_data.transactions.iter().map(|t| t).collect();
     let apply_blocks: &dyn AbstractStacksBlock = &apply_block_data;
 
     let rollback_block_data = fixtures::build_stacks_testnet_block_with_contract_deployment();
-    let rollback_transactions = rollback_block_data.transactions.iter().map(|t|t).collect();
+    let rollback_transactions = rollback_block_data.transactions.iter().map(|t| t).collect();
     let rollback_blocks: &dyn AbstractStacksBlock = &apply_block_data;
     let trigger = StacksTriggerChainhook {
         chainhook: &chainhook,
         apply: vec![(apply_transactions, apply_blocks)],
-        rollback: vec![(rollback_transactions, rollback_blocks)]
+        rollback: vec![(rollback_transactions, rollback_blocks)],
     };
 
     let proofs = HashMap::new();
-    let ctx = Context { logger: None, tracer: false };
+    let ctx = Context {
+        logger: None,
+        tracer: false,
+    };
     let occurrence = handle_stacks_hook_action(trigger, &proofs, &ctx).unwrap();
     if let StacksChainhookOccurrence::Data(data) = occurrence {
         assert_eq!(data.apply.len(), 1);
-        assert_eq!(data.apply[0].block_identifier.hash, apply_block_data.block_identifier.hash);
+        assert_eq!(
+            data.apply[0].block_identifier.hash,
+            apply_block_data.block_identifier.hash
+        );
         assert_eq!(data.rollback.len(), 1);
-        assert_eq!(data.rollback[0].block_identifier.hash, rollback_block_data.block_identifier.hash);
-    }
-    else {
+        assert_eq!(
+            data.rollback[0].block_identifier.hash,
+            rollback_block_data.block_identifier.hash
+        );
+    } else {
         panic!("wrong occurrence type");
     }
 }
-
 
 #[test]
 fn test_stacks_hook_action_file_append() {
@@ -544,30 +571,47 @@ fn test_stacks_hook_action_file_append() {
         expire_after_occurrence: None,
         capture_all_events: None,
         decode_clarity_values: Some(true),
-        predicate: StacksPredicate::Txid(ExactMatchingRule::Equals("0xb92c2ade84a8b85f4c72170680ae42e65438aea4db72ba4b2d6a6960f4141ce8".to_string())),
-        action: HookAction::FileAppend(FileHook {path: "./".to_string()}),
+        predicate: StacksPredicate::Txid(ExactMatchingRule::Equals(
+            "0xb92c2ade84a8b85f4c72170680ae42e65438aea4db72ba4b2d6a6960f4141ce8".to_string(),
+        )),
+        action: HookAction::FileAppend(FileHook {
+            path: "./".to_string(),
+        }),
         enabled: true,
     };
     let events = get_all_event_types();
     let mut apply_blocks = vec![];
     for event in events.iter() {
-        apply_blocks.push(fixtures::build_stacks_testnet_block_from_smart_contract_event_data(&vec![event.to_owned()]));
-
+        apply_blocks.push(
+            fixtures::build_stacks_testnet_block_from_smart_contract_event_data(&vec![
+                event.to_owned()
+            ]),
+        );
     }
-    let apply: Vec<(Vec<&StacksTransactionData>, &dyn AbstractStacksBlock)> = apply_blocks.iter().map(|b| (b.transactions.iter().map(|t| t).collect(), b as &dyn AbstractStacksBlock)).collect();
-
+    let apply: Vec<(Vec<&StacksTransactionData>, &dyn AbstractStacksBlock)> = apply_blocks
+        .iter()
+        .map(|b| {
+            (
+                b.transactions.iter().map(|t| t).collect(),
+                b as &dyn AbstractStacksBlock,
+            )
+        })
+        .collect();
 
     let rollback_block_data = fixtures::build_stacks_testnet_block_with_contract_deployment();
-    let rollback_transactions = rollback_block_data.transactions.iter().map(|t|t).collect();
+    let rollback_transactions = rollback_block_data.transactions.iter().map(|t| t).collect();
     let rollback_block: &dyn AbstractStacksBlock = &rollback_block_data;
     let trigger = StacksTriggerChainhook {
         chainhook: &chainhook,
         apply: apply,
-        rollback: vec![(rollback_transactions, rollback_block)]
+        rollback: vec![(rollback_transactions, rollback_block)],
     };
 
     let proofs = HashMap::new();
-    let ctx = Context { logger: None, tracer: false };
+    let ctx = Context {
+        logger: None,
+        tracer: false,
+    };
     let occurrence = handle_stacks_hook_action(trigger, &proofs, &ctx).unwrap();
     if let StacksChainhookOccurrence::File(path, bytes) = occurrence {
         assert_eq!(path, "./".to_string());
@@ -576,8 +620,7 @@ fn test_stacks_hook_action_file_append() {
         let actual = serde_json::to_string_pretty(obj).unwrap();
         let expected = get_expected_occurrence();
         assert_eq!(expected, actual);
-    }
-    else {
+    } else {
         panic!("wrong occurence type");
     }
 }

--- a/components/chainhook-sdk/src/indexer/tests/helpers/stacks_shapes.rs
+++ b/components/chainhook-sdk/src/indexer/tests/helpers/stacks_shapes.rs
@@ -3721,7 +3721,7 @@ pub fn get_vector_051() -> Vec<(BlockEvent, StacksChainEventExpectation)> {
 /// Vector 052: Generate the following blocks
 ///
 ///  [a1](1) - [b1](2) - B1(3)
-/// 
+///
 ///
 pub fn get_vector_052() -> Vec<(BlockEvent, StacksChainEventExpectation)> {
     vec![

--- a/components/chainhook-sdk/src/utils/mod.rs
+++ b/components/chainhook-sdk/src/utils/mod.rs
@@ -185,7 +185,7 @@ pub async fn send_request(
         }
         if retry >= attempts_max {
             ctx.try_log(|logger| {
-                slog::error!(logger, "unable to send request after several retries")
+                slog::warn!(logger, "unable to send request after several retries")
             });
             return Err(());
         }

--- a/components/chainhook-types-rs/Cargo.toml
+++ b/components/chainhook-types-rs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "chainhook-types"
 description = "Bitcoin and Stacks data schemas, based on the Rosetta specification"
 license = "MIT"
-version = "1.0.9"
+version = "1.0.10"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/components/chainhook-types-rs/Cargo.toml
+++ b/components/chainhook-types-rs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "chainhook-types"
 description = "Bitcoin and Stacks data schemas, based on the Rosetta specification"
 license = "MIT"
-version = "1.0.10"
+version = "1.0.11"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/components/chainhook-types-rs/src/rosetta.rs
+++ b/components/chainhook-types-rs/src/rosetta.rs
@@ -324,6 +324,7 @@ pub enum OrdinalInscriptionCurseType {
     Batch,
     P2wsh,
     Reinscription,
+    Unknown,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]

--- a/components/chainhook-types-rs/src/rosetta.rs
+++ b/components/chainhook-types-rs/src/rosetta.rs
@@ -305,7 +305,6 @@ pub struct BitcoinTransactionMetadata {
 #[serde(rename_all = "snake_case")]
 pub enum OrdinalOperation {
     InscriptionRevealed(OrdinalInscriptionRevealData),
-    CursedInscriptionRevealed(OrdinalInscriptionRevealData),
     InscriptionTransferred(OrdinalInscriptionTransferData),
 }
 

--- a/components/client/typescript/src/schemas/bitcoin/payload.ts
+++ b/components/client/typescript/src/schemas/bitcoin/payload.ts
@@ -21,6 +21,7 @@ export const BitcoinInscriptionRevealedSchema = Type.Object({
   ordinal_offset: Type.Integer(),
   satpoint_post_inscription: Type.String(),
   transfers_pre_inscription: Type.Integer(),
+  curse_type: Nullable(Type.Any()),
   tx_index: Type.Integer(),
 });
 export type BitcoinInscriptionRevealed = Static<typeof BitcoinInscriptionRevealedSchema>;
@@ -35,30 +36,7 @@ export const BitcoinInscriptionTransferredSchema = Type.Object({
 });
 export type BitcoinInscriptionTransferred = Static<typeof BitcoinInscriptionTransferredSchema>;
 
-export const BitcoinCursedInscriptionRevealedSchema = Type.Object({
-  content_bytes: Type.String(),
-  content_type: Type.String(),
-  content_length: Type.Integer(),
-  inscription_number: Type.Integer(),
-  inscription_fee: Type.Integer(),
-  inscription_id: Type.String(),
-  inscription_output_value: Type.Integer(),
-  inscription_input_index: Type.Integer(),
-  inscriber_address: Nullable(Type.String()),
-  ordinal_number: Type.Integer(),
-  ordinal_block_height: Type.Integer(),
-  ordinal_offset: Type.Integer(),
-  satpoint_post_inscription: Type.String(),
-  transfers_pre_inscription: Type.Integer(),
-  curse_type: Nullable(Type.Any()),
-  tx_index: Type.Integer(),
-});
-export type BitcoinCursedInscriptionRevealed = Static<
-  typeof BitcoinCursedInscriptionRevealedSchema
->;
-
 export const BitcoinOrdinalOperationSchema = Type.Object({
-  cursed_inscription_revealed: Type.Optional(BitcoinCursedInscriptionRevealedSchema),
   inscription_revealed: Type.Optional(BitcoinInscriptionRevealedSchema),
   inscription_transferred: Type.Optional(BitcoinInscriptionTransferredSchema),
 });


### PR DESCRIPTION
- Bump retries counts for initial scans
- Introduce new ordinals curse type wildcard
- Simplify ordinals schemas by removing curse variants
- Bump versions
- Cargo format