### PR TITLE
docs: update chainhook guides

### DIFF
--- a/docs/how-to-guides/how-to-run-chainhook-as-a-service-using-bitcoind.md
+++ b/docs/how-to-guides/how-to-run-chainhook-as-a-service-using-bitcoind.md
@@ -8,27 +8,29 @@ You can run Chainhook as a service to evaluate your `if_this / then_that` predic
 
 ### Setting up a Bitcoin Node
 
-Bitcoind is a program that implements the Bitcoin protocol for remote procedure call (RPC) use. Chainhook can be set up to interact with the Bitcoin chainstate through bitcoind's ZeroMQ interface, its embedded networking library.
+The Bitcoin Core daemon (bitcoind) is a program that implements the Bitcoin protocol for remote procedure call (RPC) use. Chainhook can be set up to interact with the Bitcoin chainstate through bitcoind's ZeroMQ interface, its embedded networking library.
 
 This guide is written to work with the latest Bitcoin Core software containing bitcoind, [Bitcoin Core 25.0](https://bitcoincore.org/bin/bitcoin-core-25.0/).
 
 > **_NOTE:_**
 >
-> While bitcoind can and will start syncing a Bitcoin node, customizing this node to your use cases beyond supporting a Chainhook is out of scope for this guide. See the Bitcoin wiki for ["Running Bitcoin"](https://en.bitcoin.it/wiki/Running_Bitcoin) or bitcoin.org [Running A Full Node guide](https://bitcoin.org/en/full-node).
-
-- Navigate to your project folder, create a new file, and rename it to `bitcoin.conf` on your local machine. Copy the configuration below to the `bitcoin.conf` file. 
-- Copy the path of your Bitcoin directory to the `bitcoin.conf`'s `datadir` field. See the Bitcoin wiki for the [list of default directories by operating system](https://en.bitcoin.it/wiki/Data_directory)
-- Set a username of your choice for bitcoind and use it in the `rpcuser` configuration below.
-- Set a password of your choice for bitcoind and use it in the `rpcpassword` configuration below.
+> The OS X .tar.gz file that includes bitcoind can be downloaded directly in terminal with the following command:
+> `curl -O https://bitcoincore.org/bin/bitcoin-core-25.0/bitcoin-25.0-x86_64-apple-darwin.tar.gz`
 
 > **_NOTE:_**
 >
-> Make a note of the `rpcuser`, `rpcpassword` and `rpcport` values to use them later in the chainhook configuration.
+> While bitcoind can and will start syncing a Bitcoin node, customizing this node to your use cases beyond supporting a Chainhook is out of scope for this guide. See the Bitcoin wiki for ["Running Bitcoin"](https://en.bitcoin.it/wiki/Running_Bitcoin) or bitcoin.org [Running A Full Node guide](https://bitcoin.org/en/full-node).
+
+- Make note of the path of your `bitcoind` executable (located within the `bin` directory of the `bitcoin-25.0` folder you downloaded above)
+- Navigate to your project folder where your Chainhook will reside, create a new file, and rename it to `bitcoin.conf` on your local machine. Copy the configuration below to this `bitcoin.conf` file. 
+- Find and copy your Bitcoin data directory and paste to the `datadir` field in the `bitcoin.conf` file below. Either copy the default path (see [list of default directories by operating system](https://en.bitcoin.it/wiki/Data_directory)) or copy the custom path you set for your Bitcoin data
+- Set a username of your choice for bitcoind and use it in the `rpcuser` configuration below (`devnet` is a default).
+- Set a password of your choice for bitcoind and use it in the `rpcpassword` configuration below (`devnet` is a default).
 
 ```conf
 # Bitcoin Core Configuration
 
-datadir=</path/to/bitcoin/directory/> # Path to existing Bitcoin folder. New data directory will be created here otherwise
+datadir=</path/to/bitcoin/directory/> # Path to Bitcoin directory
 server=1
 rpcuser=devnet
 rpcpassword=devnet
@@ -52,18 +54,17 @@ dbcache=4096
 zmqpubhashblock=tcp://0.0.0.0:18543
 ```
 
-Now that you have `bitcoin.conf` file ready with the bitcoind configurations, you can run the bitcoind node.
-In the command below, use the path to your `bitcoin.conf` file from your machine and run the command in the terminal.
+Now that you have `bitcoin.conf` file ready with the bitcoind configurations, you can run the bitcoind node. The command takes the form `<path/to/bitcoind> -conf=<path/to/bitcoin.conf>`
 
 > **_NOTE:_**
 >
 > The below command is a startup process that, if this is your first time syncing a node, might take a few hours to a few days to run. Alternatively, if the directory pointed to in the `datadir` field above contains bitcoin blockchain data, syncing will resume.
 
 ```console
-./bitcoind -conf=</path/to/bitcoin/directory/>
+/Volumes/SSD/bitcoin-25.0/bin/bitcoind -conf=</Volumes/SSD/project/Chainhook/bitcoin.conf>
 ```
 
-Once the above command runs, you will see `zmq_url` entries in the console's stdout, displaying ZeroMQ.
+Once the above command runs, you will see `zmq_url` entries in the console's stdout, displaying ZeroMQ logs of your bitcoin node.
 
 ### Configure Chainhook
 
@@ -132,7 +133,7 @@ Here is a table of the relevant parameters this guide changes in our configurati
 
 ## Scan blockchain based on predicates
 
-Now that your bitcoind and Chainhook configurations are complete, you can define the [predicates](../overview.md#if-this-predicate-design) you would like to scan against bitcoin blocks [predicates](../overview.md#if-this-predicate-design). These predicates are where the user specifies the kinds of blockchain events they want their Chainhook to trigger to the deliver a result (either a file appendation or an HTTP POST result). This section helps you with an example JSON file to scan a range of blocks in the blockchain to trigger results. To understand the supported predicates for Bitcoin, refer to [how to use chainhooks with bitcoin](how-to-use-chainhooks-with-bitcoin.md).
+Now that your bitcoind and Chainhook configurations are complete, you can define the Chainhook [predicates](../overview.md#if-this-predicate-design) you would like to scan against bitcoin blocks. These predicates are where the user specifies the kinds of blockchain events that trigger a Chainhook to the deliver a result (either a file appendation or an HTTP POST request). This section helps you with an example JSON file to scan a range of blocks in the blockchain to trigger results. To understand the supported predicates for Bitcoin, refer to [how to use chainhooks with bitcoin](how-to-use-chainhooks-with-bitcoin.md).
 
 The following is an example to walk you through an `if_this / then_that` predicate design that appends event payloads to the configured file destination.
 

--- a/docs/how-to-guides/how-to-run-chainhook-as-a-service-using-bitcoind.md
+++ b/docs/how-to-guides/how-to-run-chainhook-as-a-service-using-bitcoind.md
@@ -10,16 +10,14 @@ You can run Chainhook as a service to evaluate your `if_this / then_that` predic
 
 The Bitcoin Core daemon (bitcoind) is a program that implements the Bitcoin protocol for remote procedure call (RPC) use. Chainhook can be set up to interact with the Bitcoin chainstate through bitcoind's ZeroMQ interface, its embedded networking library, passing raw blockchain data to be evaluated for relevant events.
 
-This guide is written to work with the latest Bitcoin Core software containing bitcoind, [Bitcoin Core 25.0](https://bitcoincore.org/bin/bitcoin-core-25.0/). While bitcoind can and will start syncing a Bitcoin node, customizing this node to your use cases beyond supporting a Chainhook is out of scope for this guide. See the Bitcoin wiki for ["Running Bitcoin"](https://en.bitcoin.it/wiki/Running_Bitcoin) or bitcoin.org [Running A Full Node guide](https://bitcoin.org/en/full-node).
+This guide is written to work with the latest Bitcoin Core software containing bitcoind, [Bitcoin Core 25.0](https://bitcoincore.org/bin/bitcoin-core-25.0/). 
 
 > **_NOTE:_**
 >
-> The OS X .tar.gz file that includes bitcoind can be downloaded directly in terminal with the following command:
-> 
-> `curl -O https://bitcoincore.org/bin/bitcoin-core-25.0/bitcoin-25.0-x86_64-apple-darwin.tar.gz`
+> While bitcoind can and will start syncing a Bitcoin node, customizing this node to your use cases beyond supporting a Chainhook is out of scope for this guide. See the Bitcoin wiki for ["Running Bitcoin"](https://en.bitcoin.it/wiki/Running_Bitcoin) or bitcoin.org [Running A Full Node guide](https://bitcoin.org/en/full-node).
 
-- Make note of the path of your `bitcoind` executable (located within the `bin` directory of the `bitcoin-25.0` folder you downloaded above)
-- Navigate to your project folder where your Chainhook will reside, create a new file, and rename it to `bitcoin.conf`. Copy the configuration below to this `bitcoin.conf` file. 
+- Make note of the path of your `bitcoind` executable (located within the `bin` directory of the `bitcoin-25.0` folder you downloaded above appropriate to your operating system)
+- Navigate to your project folder where your Chainhook node will reside, create a new file, and rename it to `bitcoin.conf`. Copy the configuration below to this `bitcoin.conf` file. 
 - Find and copy your Bitcoin data directory and paste to the `datadir` field in the `bitcoin.conf` file below. Either copy the default path (see [list of default directories by operating system](https://en.bitcoin.it/wiki/Data_directory)) or copy the custom path you set for your Bitcoin data
 - Set a username of your choice for bitcoind and use it in the `rpcuser` configuration below (`devnet` is a default).
 - Set a password of your choice for bitcoind and use it in the `rpcpassword` configuration below (`devnet` is a default).
@@ -55,10 +53,10 @@ zmqpubhashblock=tcp://0.0.0.0:18543
 >
 > The below command is a startup process that, if this is your first time syncing a node, might take a few hours to a few days to run. Alternatively, if the directory pointed to in the `datadir` field above contains bitcoin blockchain data, syncing will resume.
 
-Now that you have `bitcoin.conf` file ready with the bitcoind configurations, you can run the bitcoind node. The command takes the form `<path/to/bitcoind> -conf=<path/to/bitcoin.conf>`, for example:
+Now that you have the `bitcoin.conf` file ready with the bitcoind configurations, you can run the bitcoind node. The command takes the form `<path/to/bitcoind> -conf=<path/to/bitcoin.conf>`, for example:
 
 ```console
-/Volumes/SSD/bitcoin-25.0/bin/bitcoind -conf=</Volumes/SSD/project/Chainhook/bitcoin.conf>
+/Volumes/SSD/bitcoin-25.0/bin/bitcoind -conf=/Volumes/SSD/project/Chainhook/bitcoin.conf
 ```
 
 Once the above command runs, you will see `zmq_url` entries in the console's stdout, displaying ZeroMQ logs of your bitcoin node.
@@ -87,8 +85,8 @@ working_dir = "cache"
 
 # The Http Api allows you to register / deregister
 # dynamically predicates.
-# Disable by default.
-#
+# This is disabled by default.
+
 # [http_api]
 # http_port = 20456
 # database_uri = "redis://localhost:6379/"
@@ -130,7 +128,7 @@ Here is a table of the relevant parameters this guide changes in our configurati
 
 ## Scan blockchain based on predicates
 
-Now that your bitcoind and Chainhook configurations are complete, you can define the Chainhook [predicates](../overview.md#if-this-predicate-design) you would like to scan against bitcoin blocks. These predicates are where the user specifies the kinds of blockchain events that trigger a Chainhook to the deliver a result (either a file appendation or an HTTP POST request). This section helps you with an example JSON file to scan a range of blocks in the blockchain to trigger results. To understand the supported predicates for Bitcoin, refer to [how to use chainhooks with bitcoin](how-to-use-chainhooks-with-bitcoin.md).
+Now that your bitcoind and Chainhook configurations are complete, you can define the Chainhook [predicates](../overview.md#if-this-predicate-design) you would like to scan against bitcoin blocks. These predicates are where the user specifies the kinds of blockchain events that trigger Chainhook to deliver a result (either a file appendation or an HTTP POST request). This section helps you with an example JSON file to scan a range of blocks in the blockchain to trigger results. To understand the supported predicates for Bitcoin, refer to [how to use chainhooks with bitcoin](how-to-use-chainhooks-with-bitcoin.md).
 
 The following is an example to walk you through an `if_this / then_that` predicate design that appends event payloads to the configured file destination.
 

--- a/docs/how-to-guides/how-to-run-chainhook-as-a-service-using-bitcoind.md
+++ b/docs/how-to-guides/how-to-run-chainhook-as-a-service-using-bitcoind.md
@@ -8,21 +8,18 @@ You can run Chainhook as a service to evaluate your `if_this / then_that` predic
 
 ### Setting up a Bitcoin Node
 
-The Bitcoin Core daemon (bitcoind) is a program that implements the Bitcoin protocol for remote procedure call (RPC) use. Chainhook can be set up to interact with the Bitcoin chainstate through bitcoind's ZeroMQ interface, its embedded networking library.
+The Bitcoin Core daemon (bitcoind) is a program that implements the Bitcoin protocol for remote procedure call (RPC) use. Chainhook can be set up to interact with the Bitcoin chainstate through bitcoind's ZeroMQ interface, its embedded networking library, passing raw blockchain data to be evaluated for relevant events.
 
-This guide is written to work with the latest Bitcoin Core software containing bitcoind, [Bitcoin Core 25.0](https://bitcoincore.org/bin/bitcoin-core-25.0/).
+This guide is written to work with the latest Bitcoin Core software containing bitcoind, [Bitcoin Core 25.0](https://bitcoincore.org/bin/bitcoin-core-25.0/). While bitcoind can and will start syncing a Bitcoin node, customizing this node to your use cases beyond supporting a Chainhook is out of scope for this guide. See the Bitcoin wiki for ["Running Bitcoin"](https://en.bitcoin.it/wiki/Running_Bitcoin) or bitcoin.org [Running A Full Node guide](https://bitcoin.org/en/full-node).
 
 > **_NOTE:_**
 >
 > The OS X .tar.gz file that includes bitcoind can be downloaded directly in terminal with the following command:
+> 
 > `curl -O https://bitcoincore.org/bin/bitcoin-core-25.0/bitcoin-25.0-x86_64-apple-darwin.tar.gz`
 
-> **_NOTE:_**
->
-> While bitcoind can and will start syncing a Bitcoin node, customizing this node to your use cases beyond supporting a Chainhook is out of scope for this guide. See the Bitcoin wiki for ["Running Bitcoin"](https://en.bitcoin.it/wiki/Running_Bitcoin) or bitcoin.org [Running A Full Node guide](https://bitcoin.org/en/full-node).
-
 - Make note of the path of your `bitcoind` executable (located within the `bin` directory of the `bitcoin-25.0` folder you downloaded above)
-- Navigate to your project folder where your Chainhook will reside, create a new file, and rename it to `bitcoin.conf` on your local machine. Copy the configuration below to this `bitcoin.conf` file. 
+- Navigate to your project folder where your Chainhook will reside, create a new file, and rename it to `bitcoin.conf`. Copy the configuration below to this `bitcoin.conf` file. 
 - Find and copy your Bitcoin data directory and paste to the `datadir` field in the `bitcoin.conf` file below. Either copy the default path (see [list of default directories by operating system](https://en.bitcoin.it/wiki/Data_directory)) or copy the custom path you set for your Bitcoin data
 - Set a username of your choice for bitcoind and use it in the `rpcuser` configuration below (`devnet` is a default).
 - Set a password of your choice for bitcoind and use it in the `rpcpassword` configuration below (`devnet` is a default).
@@ -54,11 +51,11 @@ dbcache=4096
 zmqpubhashblock=tcp://0.0.0.0:18543
 ```
 
-Now that you have `bitcoin.conf` file ready with the bitcoind configurations, you can run the bitcoind node. The command takes the form `<path/to/bitcoind> -conf=<path/to/bitcoin.conf>`
-
 > **_NOTE:_**
 >
 > The below command is a startup process that, if this is your first time syncing a node, might take a few hours to a few days to run. Alternatively, if the directory pointed to in the `datadir` field above contains bitcoin blockchain data, syncing will resume.
+
+Now that you have `bitcoin.conf` file ready with the bitcoind configurations, you can run the bitcoind node. The command takes the form `<path/to/bitcoind> -conf=<path/to/bitcoin.conf>`, for example:
 
 ```console
 /Volumes/SSD/bitcoin-25.0/bin/bitcoind -conf=</Volumes/SSD/project/Chainhook/bitcoin.conf>

--- a/docs/how-to-guides/how-to-run-chainhook-as-a-service-using-bitcoind.md
+++ b/docs/how-to-guides/how-to-run-chainhook-as-a-service-using-bitcoind.md
@@ -25,7 +25,7 @@ This guide is written to work with the latest Bitcoin Core software containing b
 ```conf
 # Bitcoin Core Configuration
 
-datadir=</path/to/bitcoin/directory/> # Path to Bitcoin directory
+datadir=/path/to/bitcoin/directory/ # Path to Bitcoin directory
 server=1
 rpcuser=devnet
 rpcpassword=devnet
@@ -53,7 +53,7 @@ zmqpubhashblock=tcp://0.0.0.0:18543
 >
 > The below command is a startup process that, if this is your first time syncing a node, might take a few hours to a few days to run. Alternatively, if the directory pointed to in the `datadir` field above contains bitcoin blockchain data, syncing will resume.
 
-Now that you have the `bitcoin.conf` file ready with the bitcoind configurations, you can run the bitcoind node. The command takes the form `<path/to/bitcoind> -conf=<path/to/bitcoin.conf>`, for example:
+Now that you have the `bitcoin.conf` file ready with the bitcoind configurations, you can run the bitcoind node. The command takes the form `path/to/bitcoind -conf=path/to/bitcoin.conf`, for example:
 
 ```console
 /Volumes/SSD/bitcoin-25.0/bin/bitcoind -conf=/Volumes/SSD/project/Chainhook/bitcoin.conf
@@ -84,7 +84,7 @@ Additionally, if you want to receive events from the configured Bitcoin node, su
 working_dir = "cache"
 
 # The Http Api allows you to register / deregister
-# dynamically predicates.
+# predicates dynamically.
 # This is disabled by default.
 
 # [http_api]

--- a/docs/how-to-guides/how-to-run-chainhook-as-a-service-using-stacks.md
+++ b/docs/how-to-guides/how-to-run-chainhook-as-a-service-using-stacks.md
@@ -48,10 +48,15 @@ events_keys = ["*"]
 In this section, you will configure a chainhook to communicate with the network. Run the following command in your terminal and generate the `Chainhook.toml` file.
 
 ```console
-chainhook config generate --testnet
+chainhook config generate --mainnet
 ```
 
-Ensure that the `bitcoind_rpc_url`, `bitcoind_rpc_username`, `bitcoind_rpc_password` match with the `rpcport`, `rpcuser` and `rpcpassword` in the `bitcoin.conf` file and the port of the `stacks_node_rpc_url` matches the `rpc_bind` in the `Stacks.toml` file.
+Several network parameters in the generated `Chainhook.toml` configuration file need to match those in the `bitcoin.conf` file created earlier in the [Setting up a Bitcoin Node](#setting-up-a-bitcoin-node) section. Please update the following parameters accordingly:
+
+1. Update `bitcoind_rpc_username` with the username set for `rpcuser` in `bitcoin.conf`.
+2. Update `bitcoind_rpc_password` with the password set for `rpcpassword` in `bitcoin.conf`.
+3. Update `bitcoind_rpc_url` with the same host and port used for `rpcport` in `bitcoin.conf`.
+4. Ensure `stacks_node_rpc_url` matches the `rpc_bind` in the `Stacks.toml`.
 
 The following `Chainhook.toml` file is generated:
 
@@ -59,9 +64,9 @@ The following `Chainhook.toml` file is generated:
 [storage]
 working_dir = "cache"
 
-# The HTTP API allows you to register/deregister
-# dynamically predicates
-# Disable by default
+# The Http Api allows you to register / deregister
+# dynamically predicates.
+# Disable by default.
 #
 # [http_api]
 # http_port = 20456
@@ -69,10 +74,17 @@ working_dir = "cache"
 
 [network]
 mode = "mainnet"
-bitcoind_rpc_url = "http://localhost:8332"                # Must match with the rpcport in the bitcoin.conf
-bitcoind_rpc_username = "<bitcoind_username>"             # Must match with the rpcuser in the bitcoin.conf
-bitcoind_rpc_password = "<bitcoind_password>"             # Must match with the rpcpassword in the bitcoin.conf
-stacks_node_rpc_url = "http://localhost:20443"            # Must match with the rpc_bind in the Stacks.toml file
+bitcoind_rpc_url = "http://localhost:8332"
+bitcoind_rpc_username = "devnet"
+bitcoind_rpc_password = "devnet"
+# Bitcoin block events can be received by Chainhook
+# either through a Bitcoin node's ZeroMQ interface,
+# or through the Stacks node. The Stacks node is
+# used by default:
+stacks_node_rpc_url = "http://localhost:20443"
+stacks_events_ingestion_port = 20455
+# but zmq can be used instead:
+# bitcoind_zmq_url = "tcp://0.0.0.0:18543"
 
 [limits]
 max_number_of_bitcoin_predicates = 100
@@ -85,19 +97,18 @@ max_caching_memory_size_mb = 32000
 
 [[event_source]]
 tsv_file_url = "https://archive.hiro.so/mainnet/stacks-blockchain-api/mainnet-stacks-blockchain-api-latest"
-
 ```
 
 Ensure the following configurations are matched to allow chainhook to communicate with the Stacks and Bitcoin layers.
 
-| bitcoin.conf      | Stacks.toml            | Chainhook.toml               |
-| -----------       | -----------            |  -------------               |
-| rpcuser           | username               | bitcoind_rpc_username        |
-| rpcpassword       | password               | bitcoind_rpc_password        |
-| rpcport           | rpc_port               | bitcoind_rpc_url             |
-| zmqpubhashblock   |                        | bitcoind_zmq_url             |
-|                   | rpc_bind               | stacks_node_rpc_url          |
-|                   | endpoint               | stacks_events_ingestion_port |
+| bitcoin.conf    | Stacks.toml | Chainhook.toml               |
+| --------------- | ----------- | ---------------------------- |
+| rpcuser         | username    | bitcoind_rpc_username        |
+| rpcpassword     | password    | bitcoind_rpc_password        |
+| rpcport         | rpc_port    | bitcoind_rpc_url             |
+| zmqpubhashblock |             | bitcoind_zmq_url             |
+|                 | rpc_bind    | stacks_node_rpc_url          |
+|                 | endpoint    | stacks_events_ingestion_port |
 
 > **_NOTE:_**
 >
@@ -109,33 +120,33 @@ Now that the stacks and chainhook configurations are done, you can scan your blo
 
 The following are the two examples to walk you through `file_append` and `http_post` `then-that` predicate designs.
 
-Example 1 uses a `print_event.json` file to scan the predicates and render results using `file_append`.
-Example 2 uses `print_event.json` to scan the predicates and render results using `http_post`.
+Example 1 uses a `print-event.json` file to scan the predicates and render results using `file_append`.
+Example 2 uses `print-event-post.json` to scan the predicates and render results using `http_post`.
 
 You can choose between the following examples to scan the predicates.
 
-### Example 1
+### Example 1 - `file_append`
 
 Run the following command to generate a sample JSON file with predicates in your terminal.
 
 ```console
-chainhook predicates new print_event_1.json --stacks
+chainhook predicates new print-event.json --stacks
 ```
 
-A JSON file `print_event_1.json` is generated.
+A JSON file `print-event.json` is generated.
 
 ```json
 {
   "chain": "stacks",
-  "uuid": "1da35032-e399-430c-bfbc-eca94709ad11",
+  "uuid": "6ad27176-2b83-4381-b51c-50baede11e3f",
   "name": "Hello world",
   "version": 1,
   "networks": {
     "testnet": {
-      "start_block": 0,
-      "end_block": 100,
+      "start_block": 34239,
+      "end_block": 50000,
       "if_this": {
-        "scope": "print_event_1",
+        "scope": "print_event",
         "contract_identifier": "ST1SVA0SST0EDT4MFYGWGP6GNSXMMQJDVP1G8QTTC.arkadiko-freddie-v1-1",
         "contains": "vault"
       },
@@ -146,10 +157,10 @@ A JSON file `print_event_1.json` is generated.
       }
     },
     "mainnet": {
-      "start_block": 0,
-      "end_block": 100,
+      "start_block": 34239,
+      "end_block": 50000,
       "if_this": {
-        "scope": "print_event_1",
+        "scope": "print_event",
         "contract_identifier": "SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.arkadiko-freddie-v1-1",
         "contains": "vault"
       },
@@ -167,62 +178,69 @@ A JSON file `print_event_1.json` is generated.
 >
 > You can get blockchain height and current block in the [Explorer](https://explorer.hiro.so/blocks?chain=mainnet).
 
-The sample `arkadiko.txt` should look like this:
-
-```
-{"apply":[{"block_identifier":{"hash":"0xf048102fee15dda049e6781c8e9aec1b39b1b9dc68d06fd9b84dced1b80ddd62","index":34307},"metadata":{"bitcoin_anchor_block_identifier":{"hash":"0x000000000000000000098e9ebc30e7c8e32b30ffecbd7dc5c715b5f07e1de25c","index":705648},"confirm_microblock_identifier":{"hash":"0xa65642590e98f54183a0be747a1c01e41d3ba211f6599eff2574d78ed2578468","index":2},"pox_cycle_index":18,"pox_cycle_length":2100,"pox_cycle_position":1797,"stacks_block_hash":"0x77a1aed86e895cb4b7b969986aa6a28eb2465e7227f351dd4e23d28448b222e9"},"parent_block_identifier":{"hash":"0x3117663ee5c5690d76e3f6c97597cbcc95085e7cecb0791d3edc4f95a4ce6f23","index":34306},"timestamp":1634625398,"transactions":[{"metadata":{"description":"invoked: SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.arkadiko-freddie-v1-1::collateralize-and-mint(u300000000, u130000000, (tuple (auto-payoff true) (stack-pox true)), \"STX-A\", SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.arkadiko-stx-reserve-v1-1, SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.arkadiko-token, SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.arkadiko-collateral-types-v1-1, SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.arkadiko-oracle-v1-1)","execution_cost":{"read_count":155,"read_length":318312,"runtime":349859000,"write_count":10,"write_length":3621},"fee":188800,"kind":{"data":{"args":["u300000000","u130000000","(tuple (auto-payoff true) (stack-pox true))","\"STX-A\"","SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.arkadiko-stx-reserve-v1-1","SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.arkadiko-token","SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.arkadiko-collateral-types-v1-1","SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.arkadiko-oracle-v1-1"],"contract_identifier":"SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.arkadiko-freddie-v1-1","method":"collateralize-and-mint"},"type":"ContractCall"},"nonce":15,"position":{"index":16},"proof":null,...
-```
-
-Now, use the following command to scan the blocks based on the predicates defined in the `print_event_1.json` file.
+Now, use the following command to scan the blocks based on the predicates defined in the `mainnet` network block of your `print-event.json` file.
 
 ```console
-chainhook predicates scan print_event_1.json --testnet
+chainhook predicates scan print-event.json --mainnet
 ```
 
-The output of the above command will be a text file `arkadiko.txt` generated based on the predicate definition.
+The output of the above command will be a text file `arkadiko.txt` generated based on the predicate definition. It should look something like this:
+
+```
+{"apply":[{"block_identifier":{"hash":"0xf048102fee15dda049e6781c8e9aec1b39b1b9dc68d06fd9b84dced1b80ddd62","index":34307},"metadata":{"bitcoin_anchor_block_identifier":{"hash":"0x000000000000000000098e9ebc30e7c8e32b30ffecbd7dc5c715b5f07e1de25c","index":705648},"confirm_microblock_identifier":{"hash":"0xa65642590e98f54183a0be747a1c01e41d3ba211f6599eff2574d78ed2578468","index":2},"pox_cycle_index":18,"pox_cycle_length":2100,"pox_cycle_position":1797,"stacks_block_hash":"0x77a1aed86e895cb4b7b969986aa6a28eb2465e7227f351dd4e23d28448b222e9"},"parent_block_identifier":{"hash":"0x3117663ee5c5690d76e3f6c97597cbcc95085e7cecb0791d3edc4f95a4ce6f23","index":34306},"timestamp":1634625398,"transactions":[{"metadata":{"description":"invoked: SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.arkadiko-freddie-v1-1::collateralize-and-mint(u300000000, u130000000, (tuple (auto-payoff true) (stack-pox true)), \"STX-A\", SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.arkadiko-stx-reserve-v1-1, SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.arkadiko-token, SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.arkadiko-collateral-types-v1-1, SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.arkadiko-oracle-v1-1)","execution_cost":{"read_count":155,"read_length":318312,"runtime":349859000,"write_count":10,"write_length":3621},"fee":188800,"kind":{"data":{"args":["u300000000","u130000000","(tuple (auto-payoff true) (stack-pox true))","\"STX-A\"","SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.arkadiko-stx-reserve-v1-1","SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.arkadiko-token","SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.arkadiko-collateral-types-v1-1","SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.arkadiko-oracle-v1-1"],"contract_identifier":"SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.arkadiko-freddie-v1-1","method":"collateralize-and-mint"},"type":"ContractCall"},"nonce":15,"position":{"index":16},"proof":null,"raw_tx":"0x000000000104003936cedf1ddb6bc1aa6f243772cab048c586a18b000000000000000f000000000002e1800001b563c7e917648668a796d972ef9352b76035102c6159c2061bc9e9a0d161098e1ebd17d6c0754e0308d2b53ef1035e5dcfba37f0cc6f16e69f842ad7f6b691980302000000010002163936cedf1ddb6bc1aa6f243772cab048c586a18b010000000011e1a3000216982f3ec112a5f5928a5c96a914bd733793b896a51561726b6164696b6f2d667265646469652d76312d3116636f6c6c61746572616c697a652d616e642d6d696e74000000080100000000000000000000000011e1a3000100000000000000000000000007bfa4800c000000020b6175746f2d7061796f66660309737461636b2d706f78030d000000055354582d410616982f3ec112a5f5928a5c96a914bd733793b896a51961726b6164696b6f2d7374782d726573657276652d76312d310616982f3ec112a5f5928a5c96a914bd733793b896a50e61726b6164696b6f2d746f6b656e0616982f3ec112a5f5928a5c96a914bd733793b896a51e61726b6164696b6f2d636f6c6c61746572616c2d74797065732d76312d310616982f3ec112a5f5928a5c96a914bd733793b896a51461726b6164696b6f2d6f7261636c652d76312d31","receipt":{"contract_calls_stack":[],"events":[{"data":{"amount":"130000000","asset_identifier":"SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.usda-token::usda","recipient":"SPWKDKPZ3QDPQGDADWJ3EWPAP14CB1N1HDQ897W5"},"type":"FTMintEvent"},{"data":{"contract_identifier":"SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.arkadiko-freddie-v1-1","raw_value":"0x0c0000000306616374696f6e0d000000076372656174656404646174610c000000110d61756374696f6e2d656e646564040b6175746f2d7061796f6666030a636f6c6c61746572616c0100000000000000000000000011e1a30010636f6c6c61746572616c2d746f6b656e0d000000035354580f636f6c6c61746572616c2d747970650d000000055354582d4117637265617465642d61742d626c6f636b2d686569676874010000000000000000000000000000860304646562740100000000000000000000000007bfa48002696401000000000000000000000000000000010d69732d6c69717569646174656404136c6566746f7665722d636f6c6c61746572616c0100000000000000000000000000000000056f776e657205163936cedf1ddb6bc1aa6f243772cab048c586a18b107265766f6b65642d737461636b696e67041573746162696c6974792d6665652d6163637275656401000000000000000000000000000000001a73746162696c6974792d6665652d6c6173742d6163637275656401000000000000000000000000000086030e737461636b65642d746f6b656e730100000000000000000000000011e1a3000c737461636b65722d6e616d650d00000007737461636b657217757064617465642d61742d626c6f636b2d686569676874010000000000000000000000000000860304747970650d000000057661756c74","topic":"print"},"type":"SmartContractEvent"},{"data":{"amount":"300000000","recipient":"SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.arkadiko-stx-reserve-v1-1","sender":"SPWKDKPZ3QDPQGDADWJ3EWPAP14CB1N1HDQ897W5"},"type":"STXTransferEvent"},{"data":{"contract_identifier":"SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.arkadiko-dao","raw_value":"0x0c0000000306616374696f6e0d000000066d696e74656404646174610c0000000206616d6f756e740100000000000000000000000007bfa48009726563697069656e7405163936cedf1ddb6bc1aa6f243772cab048c586a18b04747970650d00000005746f6b656e","topic":"print"},"type":"SmartContractEvent"},{"data":{"contract_identifier":"SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.arkadiko-stx-reserve-v1-1","raw_value":"0x0703","topic":"print"},"type":"SmartContractEvent"}],"mutated_assets_radius":["SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.usda-token::usda"],"mutated_contracts_radius":["SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.arkadiko-dao","SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.arkadiko-stx-reserve-v1-1","SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.arkadiko-freddie-v1-1","SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.usda-token"]},"result":"(ok u130000000)","sender":"SPWKDKPZ3QDPQGDADWJ3EWPAP14CB1N1HDQ897W5","success":true},"operations":[{"account":{"address":"SPWKDKPZ3QDPQGDADWJ3EWPAP14CB1N1HDQ897W5"},"amount":{"currency":{"decimals":6,"metadata":{"asset_class_identifier":"SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.usda-token::usda","asset_identifier":null,"standard":"SIP10"},"symbol":"TOKEN"},"value":130000000},"operation_identifier":{"index":0},"status":"SUCCESS","type":"CREDIT"},{"account":{"address":"SPWKDKPZ3QDPQGDADWJ3EWPAP14CB1N1HDQ897W5"},"amount":{"currency":{"decimals":6,"symbol":"STX"},"value":300000000},"operation_identifier":{"index":1},"related_operations":[{"index":2}],"status":"SUCCESS","type":"DEBIT"},{"account":{"address":"SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.arkadiko-stx-reserve-v1-1"},"amount":{"currency":{"decimals":6,"symbol":"STX"},"value":300000000},"operation_identifier":{"index":2},"related_operations":[{"index":1}],"status":"SUCCESS","type":"CREDIT"}],"transaction_identifier":{"hash":"0x580d89b79f4e7cda9e2ae9f1a70a5392149a055b0b6f25968afb80c6cc09306a"}}]}],"chainhook":{"is_streaming_blocks":false,"predicate":{"contains":"vault","contract_identifier":"SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.arkadiko-freddie-v1-1","scope":"print_event"},"uuid":"6ad27176-2b83-4381-b51c-50baede11e3f"},"rollback":[]}
+```
 
 > **_TIP:_**
 > To optimize your experience with scanning, the following are a few knobs you can play with:
 > Use of adequate values for `start_block` and `end_block` in predicates will drastically improve the performance.
 > Networking: reducing the number of network hops between the chainhook and the bitcoind processes can also help.
 
-The sample output file, `arkadiko.txt,` looks like this:
-
-```text
-{"apply":[{"block_identifier":{"hash":"0xf048102fee15dda049e6781c8e9aec1b39b1b9dc68d06fd9b84dced1b80ddd62","index":34307},"metadata":{"bitcoin_anchor_block_identifier":{"hash":"0x000000000000000000098e9ebc30e7c8e32b30ffecbd7dc5c715b5f07e1de25c","index":705648},"confirm_microblock_identifier":{"hash":"0xa65642590e98f54183a0be747a1c01e41d3ba211f6599eff2574d78ed2578468","index":2},"pox_cycle_index":18,"pox_cycle_length":2100,"pox_cycle_position":1797,"stacks_block_hash":"0x77a1aed86e895cb4b7b969986aa6a28eb2465e7227f351dd4e23d28448b222e9"},"parent_block_identifier":{"hash":"0x3117663ee5c5690d76e3f6c97597cbcc95085e7cecb0791d3edc4f95a4ce6f23","index":34306},"timestamp":1634625398,"transactions":[{"metadata":{"description":"invoked: SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.arkadiko-freddie-v1-1::collateralize-and-mint(u300000000, u130000000, (tuple (auto-payoff true) (stack-pox true)), \"STX-A\", SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.arkadiko-stx-reserve-v1-1, SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.arkadiko-token, SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.arkadiko-collateral-types-v1-1, SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.arkadiko-oracle-v1-1)","execution_cost":{"read_count":155,"read_length":318312,"runtime":349859000,"write_count":10,"write_length":3621},"fee":188800,"kind":{"data":{"args":["u300000000","u130000000","(tuple (auto-payoff true) (stack-pox true))","\"STX-A\"",.........
-```
-
-### Example 2
+### Example 2 - `http_post`
 
 Run the following command to generate a sample JSON file with predicates in your terminal.
 
 ```console
-chainhook predicates new print_event_2.json --stacks
+chainhook predicates new print-event-post.json --stacks
 ```
 
-A JSON file `print_event_2.json` is generated.
+Update the generated JSON file `print-event-post.json` with the following:
 
 ```json
 {
   "chain": "stacks",
-  "uuid": "1",
-  "name": "Lorem ipsum",
+  "uuid": "e5fa09b2-ec3e-4b6a-9a4a-0ebb454f6e19",
+  "name": "Hello world",
   "version": 1,
   "networks": {
     "testnet": {
-        "if_this": {
-            "scope": "print_event_2",
-            "contract_identifier": "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.monkey-sip09",
-            "contains": "vault"
-        },
-        "then_that": {
-            "http_post": {
-            "url": "http://localhost:3000/api/v1/vaults",
-            "authorization_header": "Bearer cn389ncoiwuencr"
-            }
-        },
-        "start_block": 10200,
-        "expire_after_occurrence": 5,
+      "if_this": {
+        "scope": "print_event",
+        "contract_identifier": "ST1SVA0SST0EDT4MFYGWGP6GNSXMMQJDVP1G8QTTC.arkadiko-freddie-v1-1",
+        "contains": "vault"
+      },
+      "then_that": {
+        "http_post": {
+          "url": "http://localhost:3000/events",
+          "authorization_header": "Bearer cn389ncoiwuencr"
+        }
+      },
+      "start_block": 10200,
+      "expire_after_occurrence": 5
+    },
+    "mainnet": {
+      "if_this": {
+        "scope": "print-event",
+        "contract_identifier": "SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.arkadiko-freddie-v1-1",
+        "contains": "vault"
+      },
+      "then_that": {
+        "http_post": {
+          "url": "http://localhost:3000/events",
+          "authorization_header": "Bearer cn389ncoiwuencr"
+        }
+      },
+      "start_block": 10200,
+      "expire_after_occurrence": 5
     }
   }
 }
@@ -232,13 +250,13 @@ A JSON file `print_event_2.json` is generated.
 >
 > The `start_block` is the required field to use the `http_post` `then-that` predicate.
 
-Now, use the following command to scan the blocks based on the predicates defined in the `print_event_2.json` file.
+Now, use the following command to scan the blocks based on the predicates defined in the `print-event-post.json` file.
 
 ```console
-chainhook predicates scan print_event_2.json --testnet
+chainhook predicates scan print-event-post.json --mainnet
 ```
 
-The above command posts events to the URL `http://localhost:3000/api/v1/vaults` mentioned in the `Chainhook.toml` file.
+The above command posts events to the URL `http://localhost:3000/events` mentioned in the `Chainhook.toml` file.
 
 ## Initiate Chainhook Service
 
@@ -247,23 +265,76 @@ In this section, you'll learn how to initiate the chainhook service using the fo
 - Initiate the chainhook service by passing the predicate path to the command as shown below.
 
   ```console
-  chainhook service start --predicate-path=print_event_1.json --config-path=Chainhook.toml
+  chainhook service start --predicate-path=print-event.json --config-path=Chainhook.toml
   ```
 
-  The above command registers the predicates based on the predicate definition in the `print_event_1.json` file.
-  
-- You can also dynamically register predicates via the predicate registration server. To do this:
-  - Uncomment the following lines of code in the `Chainhook.toml` file to enable the predicate registration server.
-    ```
-    [http_api]
-    http_port = 20456
-    database_uri = "redis://localhost:6379/"
-    ```
-  - Start the Chainhook service by running ```chainhook service start --config-path=Chainhook.toml```.
-  - Now, the predicate registration server is running at `localhost:20456`. To dynamically register a new predicate, send a POST request to `localhost:20456/v1/chainhooks` with the new predicate, in JSON format, included in the request body. For complete documentation on the API endpoints available, see the [OpenAPI](https://raw.githubusercontent.com/hirosystems/chainhook/develop/docs/chainhook-openapi.json) specification.
-  - ![Example post request](../images/chainhook-post-request.jpeg)
+  The above command registers the predicates based on the predicate definition in the `print-event.json` file.
+
+## Dynamically Register Predicates
+
+You can also dynamically register new predicates with your Chainhook service.
+
+First, we need to uncomment the following lines of code in the `Chainhook.toml` file to enable the predicate registration server.
+
+```toml
+# ...
+
+[http_api]
+http_port = 20456
+database_uri = "redis://localhost:6379/"
+
+# ...
+```
+
+> **_NOTE:_**
+>
+> This assumes you have a local instance of [Redis](https://redis.io/docs/getting-started/) running.
+
+Start the Chainhook service by running the following command:
+
+```
+chainhook service start --config-path=Chainhook.toml
+```
+
+To dynamically register a new predicate, send a POST request to the running predicate registration server at `localhost:20456/v1/chainhooks`. Include the new predicate in JSON format within the request body. In another terminal window, use the following `curl` command as an example:
+
+```console
+curl -X POST \
+  -H "Content-Type: application/json" \
+  -d '{
+    "chain": "stacks",
+    "uuid": "42",
+    "name": "Arkadiko",
+    "version": 1,
+    "networks": {
+      "mainnet": {
+        "start_block": 777534,
+        "if_this": {
+          "scope": "print-event",
+          "contract_identifier": "SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.arkadiko-freddie-v1-1",
+          "contains": "vault"
+        },
+        "then_that": {
+          "http_post": {
+            "url": "http://localhost:3000/events",
+            "authorization_header": "Bearer cn389ncoiwuencr"
+          }
+        }
+      }
+    }
+  }' \
+  http://localhost:20456/v1/chainhooks
+```
+
+You should see in your terminal:
+
+```console
+{"result":"42","status":200}
+```
+
+And if you hop back over to your `Chainhook` service terminal window, you will see that your predicate has been registered.
 
 > **_TIP:_**
 >
 > You can also run chainhook service by passing multiple predicates.
-> Example:  ```chainhook service start --predicate-path=predicate_1.json --predicate-path=predicate_2.json --config-path=Chainhook.toml```
+> Example: `chainhook service start --predicate-path=predicate_1.json --predicate-path=predicate_2.json --config-path=Chainhook.toml`


### PR DESCRIPTION
### Description

@mefrem: Fixed a pathname error in docs, fixed a typo, and added some clarifying language to other sections.

- Fixed `bitcoind` and `bitcoin.conf` pathnames
- Removed double words "predicates" 
- Clarified bitcoind node setup instructions

@ryanwaits to add changes/comments to the "Run Chainhook as a Service using Stacks" How To guide
