### PR TITLE
fix: retrieve blocks until tip

### DIFF
--- a/components/chainhook-cli/src/scan/bitcoin.rs
+++ b/components/chainhook-cli/src/scan/bitcoin.rs
@@ -54,7 +54,7 @@ pub async fn scan_bitcoin_chainstate_via_rpc_using_predicate(
         let (end_block, update_end_block) = match predicate_spec.end_block {
             Some(end_block) => (end_block, false),
             None => match bitcoin_rpc.get_blockchain_info() {
-                Ok(result) => (result.blocks - 1, true),
+                Ok(result) => (result.blocks, true),
                 Err(e) => {
                     return Err(format!(
                         "unable to retrieve Bitcoin chain tip ({})",


### PR DESCRIPTION
### Description
When scanning the chain `chainhook predicates scan` setting a `start_block` predicate param, blockchain tip is not evaluated. I don't know if this was intended (leaving tip unscanned) but it's misleading to skip the tip.

#### Breaking change?

Unlikely