### PR TITLE
fix: correctly calculate evaluations for predicate status

### DIFF
--- a/components/chainhook-cli/src/scan/bitcoin.rs
+++ b/components/chainhook-cli/src/scan/bitcoin.rs
@@ -219,6 +219,15 @@ pub async fn scan_bitcoin_chainstate_via_rpc_using_predicate(
     );
 
     if let Some(ref mut predicates_db_conn) = predicates_db_conn {
+        set_predicate_scanning_status(
+            &predicate_spec.key(),
+            number_of_blocks_to_scan,
+            number_of_blocks_scanned,
+            number_of_times_triggered,
+            last_block_scanned.index,
+            predicates_db_conn,
+            ctx,
+        );
         if let Some(predicate_end_block) = predicate_spec.end_block {
             if predicate_end_block == last_block_scanned.index {
                 // todo: we need to find a way to check if this block is confirmed
@@ -237,15 +246,6 @@ pub async fn scan_bitcoin_chainstate_via_rpc_using_predicate(
                 return Ok(true);
             }
         }
-        set_predicate_scanning_status(
-            &predicate_spec.key(),
-            number_of_blocks_to_scan,
-            number_of_blocks_scanned,
-            number_of_times_triggered,
-            last_block_scanned.index,
-            predicates_db_conn,
-            ctx,
-        );
     }
 
     return Ok(false);

--- a/components/chainhook-cli/src/scan/stacks.rs
+++ b/components/chainhook-cli/src/scan/stacks.rs
@@ -377,6 +377,15 @@ pub async fn scan_stacks_chainstate_via_rocksdb_using_predicate(
     );
 
     if let Some(ref mut predicates_db_conn) = predicates_db_conn {
+        set_predicate_scanning_status(
+            &predicate_spec.key(),
+            number_of_blocks_to_scan,
+            number_of_blocks_scanned,
+            number_of_times_triggered,
+            last_block_scanned.index,
+            predicates_db_conn,
+            ctx,
+        );
         if let Some(predicate_end_block) = predicate_spec.end_block {
             if predicate_end_block == last_block_scanned.index {
                 let is_confirmed = match get_stacks_block_at_block_height(
@@ -412,15 +421,6 @@ pub async fn scan_stacks_chainstate_via_rocksdb_using_predicate(
                 return Ok((last_block_scanned, true));
             }
         }
-        set_predicate_scanning_status(
-            &predicate_spec.key(),
-            number_of_blocks_to_scan,
-            number_of_blocks_scanned,
-            number_of_times_triggered,
-            last_block_scanned.index,
-            predicates_db_conn,
-            ctx,
-        );
     }
     Ok((last_block_scanned, false))
 }

--- a/components/chainhook-cli/src/service/mod.rs
+++ b/components/chainhook-cli/src/service/mod.rs
@@ -838,9 +838,7 @@ pub fn set_predicate_scanning_status(
     );
 }
 
-/// Updates a predicate's status to `InitialScanCompleted`.
-///
-/// Preserves the scanning metrics from the predicate's previous status
+/// Updates a predicate's status to `UnconfirmedExpiration`.
 pub fn set_unconfirmed_expiration_status(
     chain: &Chain,
     number_of_new_blocks_evaluated: u64,
@@ -860,12 +858,12 @@ pub fn set_unconfirmed_expiration_status(
         Some(status) => match status {
             PredicateStatus::Scanning(ScanningData {
                 number_of_blocks_to_scan: _,
-                number_of_blocks_evaluated,
+                number_of_blocks_evaluated: _,
                 number_of_times_triggered,
                 last_occurrence,
                 last_evaluated_block_height,
             }) => (
-                number_of_blocks_evaluated + number_of_new_blocks_evaluated,
+                number_of_new_blocks_evaluated,
                 number_of_times_triggered,
                 last_occurrence,
                 last_evaluated_block_height,
@@ -1042,7 +1040,6 @@ pub fn update_predicate_status(
     ctx: &Context,
 ) {
     let serialized_status = json!(status).to_string();
-    println!("serialized predicate status {serialized_status}");
     if let Err(e) =
         predicates_db_conn.hset::<_, _, _, ()>(&predicate_key, "status", &serialized_status)
     {


### PR DESCRIPTION
### Description

Previously, when the unconfirmed predicate status was set after the status originally was scanning, we were adding the number of evaluated blocks with the previous statuses number of blocks. When scanning, we have a running total of blocks scanned, so we don't need to use the previously stored data.

---

### Checklist

- [x] All tests pass
- [x] Tests added in this PR (if applicable)

