### PR TITLE
fix: make predicate status timestamps optional

### DIFF
--- a/components/chainhook-cli/src/service/mod.rs
+++ b/components/chainhook-cli/src/service/mod.rs
@@ -547,9 +547,6 @@ pub enum PredicateStatus {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
-// note: last_occurrence (and other time-based fields on the status structs) originally were
-// of type u128. serde can't handle deserializing u128s when using an adjacently tagged enum,
-// so we're having to convert to a string. serde issue: https://github.com/serde-rs/json/issues/740
 pub struct ScanningData {
     pub number_of_blocks_to_scan: u64,
     pub number_of_blocks_evaluated: u64,

--- a/components/chainhook-cli/src/service/tests/mod.rs
+++ b/components/chainhook-cli/src/service/tests/mod.rs
@@ -966,21 +966,21 @@ async fn test_deregister_predicate(chain: Chain) {
     number_of_blocks_evaluated: 4,
     number_of_blocks_to_scan: 1,
     number_of_times_triggered: 0,
-    last_occurrence: format!("0"),
+    last_occurrence: None,
     last_evaluated_block_height: 4
 }), 6 => using assert_confirmed_expiration_status; "preloaded predicate with scanning status should get scanned until completion")]
 #[test_case(Streaming(StreamingData {
     number_of_blocks_evaluated: 4,
     number_of_times_triggered: 0,
-    last_occurrence: format!("0"),
-    last_evaluation: format!("0"),
+    last_occurrence: None,
+    last_evaluation: 0,
     last_evaluated_block_height: 4
 }), 6 => using assert_confirmed_expiration_status; "preloaded predicate with streaming status and last evaluated height below tip should get scanned until completion")]
 #[test_case(Streaming(StreamingData {
     number_of_blocks_evaluated: 5,
     number_of_times_triggered: 0,
-    last_occurrence: format!("0"),
-    last_evaluation: format!("0"),
+    last_occurrence: None,
+    last_evaluation: 0,
     last_evaluated_block_height: 5
 }), 5 => using assert_streaming_status; "preloaded predicate with streaming status and last evaluated height at tip should be streamed")]
 #[tokio::test]


### PR DESCRIPTION
### Description

This changes the predicate status timestamps:
 - from String (converted from a u128) to a u64
   - this means we are now storing the data in seconds rather than milliseconds
 - makes them optional (so they will not appear in a serialized status if set to `None`)

#### Breaking change?

Previously the timestamp was in milliseconds, now it's in seconds. Anyone depending on the timestamp being in milliseconds could be impacted by this change.


---

### Checklist

- [ ] All tests pass
- [ ] Tests added in this PR (if applicable)

