### PR TITLE
fix: redis conn

### DIFF
--- a/components/chainhook-sdk/src/indexer/stacks/mod.rs
+++ b/components/chainhook-sdk/src/indexer/stacks/mod.rs
@@ -342,7 +342,7 @@ pub fn standardize_stacks_block(
             index: match block.block_height {
                 0 => 0,
                 _ => block.block_height - 1,
-            }
+            },
         },
         timestamp: block.parent_burn_block_timestamp,
         metadata: StacksBlockMetadata {


### PR DESCRIPTION
This PR is fixing the management of the redis connection. In the current approach, we're reusing an existing connection that is being opened at startup for test purposes, but that can get broken after some time if blocks take time to arrive.
Fix: we open/close a new connection every time a new block hits the API.