### PR TITLE
fix(stacks-indexer): prevent subtract with overflow

### DIFF
--- a/components/chainhook-sdk/src/indexer/stacks/mod.rs
+++ b/components/chainhook-sdk/src/indexer/stacks/mod.rs
@@ -253,8 +253,10 @@ pub fn standardize_stacks_block(
     let pox_cycle_length: u64 = (chain_ctx.pox_info.prepare_phase_block_length
         + chain_ctx.pox_info.reward_phase_block_length)
         .into();
-    let current_len =
-        block.burn_block_height - (1 + chain_ctx.pox_info.first_burnchain_block_height);
+    let current_len = u64::saturating_sub(
+        block.burn_block_height,
+        1 + chain_ctx.pox_info.first_burnchain_block_height,
+    );
     let pox_cycle_id: u32 = (current_len / pox_cycle_length).try_into().unwrap_or(0);
     let mut events: HashMap<&String, Vec<&NewEvent>> = HashMap::new();
     for event in block.events.iter() {


### PR DESCRIPTION
I was attempting to update Clarinet to the latest version of chainhook-sdk/types, and I ran into this issue when testing the devnet.

The devnet mines 100 bitcoin blocks, and the default `pox_info.first_burnchain_block_height` is also 100, so devnet startup would always fail.