### PR TITLE
fix: buffer decoding of archive file to reduce memory usage

### DIFF
--- a/components/chainhook-cli/src/archive/mod.rs
+++ b/components/chainhook-cli/src/archive/mod.rs
@@ -52,7 +52,6 @@ pub async fn download_tsv_file(config: &Config) -> Result<(), String> {
             match decoder.read(&mut buffer) {
                 Ok(0) => break,
                 Ok(n) => {
-                    println!("bytes read: {}", n);
                     if let Err(e) = file.write_all(&buffer[..n]) {
                         let err = format!("unable to update compressed archive: {}", e.to_string());
                         return Err(err);

--- a/components/chainhook-cli/src/service/http_api.rs
+++ b/components/chainhook-cli/src/service/http_api.rs
@@ -348,7 +348,7 @@ pub fn load_predicates_from_redis(
     ctx: &Context,
 ) -> Result<Vec<(ChainhookSpecification, PredicateStatus)>, String> {
     let redis_uri: &str = config.expected_api_database_uri();
-    let client = redis::Client::open(redis_uri.clone())
+    let client = redis::Client::open(redis_uri)
         .map_err(|e| format!("unable to connect to redis: {}", e.to_string()))?;
     let mut predicate_db_conn = client
         .get_connection()


### PR DESCRIPTION
Fixes #401 

Previously, memory usage peaked at 32 GB. Now, I didn't see it go above 8 MB

