### PR TITLE
chore: upgrade `rocket` version to resolve conflicts with other deps

### DIFF
--- a/components/chainhook-sdk/Cargo.toml
+++ b/components/chainhook-sdk/Cargo.toml
@@ -20,7 +20,7 @@ hiro-system-kit = { version = "0.3.1", optional = true }
 # clarinet-utils = { version = "1", path = "../../../clarinet/components/clarinet-utils" }
 # hiro-system-kit = { version = "0.1.0", path = "../../../clarinet/components/hiro-system-kit" }
 chainhook-types = { version = "1.2.0", path = "../chainhook-types-rs" }
-rocket = { version = "=0.5.0-rc.3", features = ["json"] }
+rocket = { version = "0.5.0", features = ["json"] }
 bitcoincore-rpc = "0.16.0"
 bitcoincore-rpc-json = "0.16.0"
 base64 = "0.13.0"


### PR DESCRIPTION
After syncing the `feat/clarity-wasm-next` branch of stacks-core with `next`, I ran into a dependency conflict when building clarinet and traced it back to here.

```
error: failed to select a version for `tracing-subscriber`.
    ... required by package `wsts v5.0.0`
    ... which satisfies dependency `wsts = "^5.0"` of package `stacks-common v0.0.2 (/Users/brice/work/clarity-wasm/stacks-blockchain/stacks-common)`
    ... which satisfies path dependency `stacks_common` of package `clarity v2.2.0 (/Users/brice/work/clarity-wasm/stacks-blockchain/clarity)`
    ... which satisfies path dependency `clarity` of package `clarity-repl v2.1.0 (/Users/brice/work/clarinet/components/clarity-repl)`
    ... which satisfies path dependency `clarity_repl` (locked to 2.1.0) of package `clarinet-cli v2.0.0 (/Users/brice/work/clarinet/components/clarinet-cli)`
versions that meet the requirements `^0.3.17` are: 0.3.18, 0.3.17

all possible versions conflict with previously selected packages.

  previously selected package `tracing-subscriber v0.3.16`
    ... which satisfies dependency `tracing-subscriber = "^0.3"` (locked to 0.3.16) of package `loom v0.5.6`
    ... which satisfies dependency `loom = "^0.5"` (locked to 0.5.6) of package `state v0.5.3`
    ... which satisfies dependency `state = "^0.5.1"` (locked to 0.5.3) of package `rocket v0.5.0-rc.3`
    ... which satisfies dependency `rocket = "=0.5.0-rc.3"` (locked to 0.5.0-rc.3) of package `chainhook-sdk v0.11.0 (https://github.com/hirosystems/chainhook.git?branch=chore/remove-clarity-vm#bdf3ae19)`
    ... which satisfies git dependency `chainhook-sdk` (locked to 0.11.0) of package `stacks-network v2.0.0 (/Users/brice/work/clarinet/components/stacks-network)`
    ... which satisfies path dependency `stacks-network` (locked to 2.0.0) of package `clarinet-cli v2.0.0 (/Users/brice/work/clarinet/components/clarinet-cli)`

failed to select a version for `tracing-subscriber` which could resolve this conflict 
```