### PR TITLE
feat: optionally serve Prometheus metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,6 +462,7 @@ dependencies = [
  "hyper",
  "lazy_static",
  "miniscript",
+ "prometheus",
  "rand 0.8.5",
  "regex",
  "reqwest",
@@ -2370,6 +2371,27 @@ dependencies = [
  "version_check",
  "yansi 1.0.0-rc.1",
 ]
+
+[[package]]
+name = "prometheus"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "protobuf",
+ "thiserror",
+]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "psm"

--- a/components/chainhook-cli/src/cli/mod.rs
+++ b/components/chainhook-cli/src/cli/mod.rs
@@ -193,6 +193,9 @@ struct StartCommand {
     /// Start REST API for managing predicates
     #[clap(long = "start-http-api")]
     pub start_http_api: bool,
+    /// If provided, serves Prometheus metrics at localhost:{port}/metrics. If not specified, does not start Prometheus server.
+    #[clap(long = "prometheus-port")]
+    pub prometheus_monitoring_port: Option<u16>,
 }
 
 #[derive(Subcommand, PartialEq, Clone, Debug)]
@@ -291,8 +294,10 @@ async fn handle_command(opts: Opts, ctx: Context) -> Result<(), String> {
     match opts.command {
         Command::Service(subcmd) => match subcmd {
             ServiceCommand::Start(cmd) => {
-                let config =
+                let mut config =
                     Config::default(cmd.devnet, cmd.testnet, cmd.mainnet, &cmd.config_path)?;
+
+                config.monitoring.prometheus_monitoring_port = cmd.prometheus_monitoring_port;
 
                 let predicates = cmd
                     .predicates_paths

--- a/components/chainhook-cli/src/cli/mod.rs
+++ b/components/chainhook-cli/src/cli/mod.rs
@@ -297,7 +297,9 @@ async fn handle_command(opts: Opts, ctx: Context) -> Result<(), String> {
                 let mut config =
                     Config::default(cmd.devnet, cmd.testnet, cmd.mainnet, &cmd.config_path)?;
 
-                config.monitoring.prometheus_monitoring_port = cmd.prometheus_monitoring_port;
+                if cmd.prometheus_monitoring_port.is_some() {
+                    config.monitoring.prometheus_monitoring_port = cmd.prometheus_monitoring_port;
+                }
 
                 let predicates = cmd
                     .predicates_paths

--- a/components/chainhook-cli/src/config/file.rs
+++ b/components/chainhook-cli/src/config/file.rs
@@ -7,6 +7,7 @@ pub struct ConfigFile {
     pub event_source: Option<Vec<EventSourceConfigFile>>,
     pub limits: LimitsConfigFile,
     pub network: NetworkConfigFile,
+    pub monitoring: Option<MonitoringConfigFile>,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -80,4 +81,9 @@ impl NetworkConfigMode {
             NetworkConfigMode::Signet => "signet",
         }
     }
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct MonitoringConfigFile {
+    pub prometheus_monitoring_port: Option<u16>,
 }

--- a/components/chainhook-cli/src/config/generator.rs
+++ b/components/chainhook-cli/src/config/generator.rs
@@ -45,6 +45,11 @@ max_caching_memory_size_mb = 32000
 # If this is not a requirement, you can comment out the `tsv_file_url` line.
 [[event_source]]
 tsv_file_url = "https://archive.hiro.so/{network}/stacks-blockchain-api/{network}-stacks-blockchain-api-latest"
+
+# Enables a server that provides metrics that can be scraped by Prometheus.
+# This is disabled by default.
+# [monitoring]
+# prometheus_monitoring_port = 1111
 "#,
         mode = mode.as_str(),
         network = network.to_lowercase(),

--- a/components/chainhook-cli/src/config/generator.rs
+++ b/components/chainhook-cli/src/config/generator.rs
@@ -49,7 +49,7 @@ tsv_file_url = "https://archive.hiro.so/{network}/stacks-blockchain-api/{network
 # Enables a server that provides metrics that can be scraped by Prometheus.
 # This is disabled by default.
 # [monitoring]
-# prometheus_monitoring_port = 1111
+# prometheus_monitoring_port = 20457
 "#,
         mode = mode.as_str(),
         network = network.to_lowercase(),

--- a/components/chainhook-cli/src/config/mod.rs
+++ b/components/chainhook-cli/src/config/mod.rs
@@ -162,7 +162,7 @@ impl Config {
             http_api: match config_file.http_api {
                 None => PredicatesApi::Off,
                 Some(http_api) => match http_api.disabled {
-                    Some(false) => PredicatesApi::Off,
+                    Some(true) => PredicatesApi::Off,
                     _ => PredicatesApi::On(PredicatesApiConfig {
                         http_port: http_api.http_port.unwrap_or(DEFAULT_CONTROL_PORT),
                         display_logs: http_api.display_logs.unwrap_or(true),

--- a/components/chainhook-cli/src/config/mod.rs
+++ b/components/chainhook-cli/src/config/mod.rs
@@ -31,6 +31,7 @@ pub struct Config {
     pub event_sources: Vec<EventSourceConfig>,
     pub limits: LimitsConfig,
     pub network: IndexerConfig,
+    pub monitoring: MonitoringConfig,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -80,6 +81,10 @@ pub struct LimitsConfig {
     pub max_caching_memory_size_mb: usize,
 }
 
+#[derive(Clone, Debug, PartialEq)]
+pub struct MonitoringConfig {
+    pub prometheus_monitoring_port: Option<u16>,
+}
 impl Config {
     pub fn from_file_path(file_path: &str) -> Result<Config, String> {
         let file = File::open(file_path)
@@ -120,6 +125,7 @@ impl Config {
             bitcoin_network: self.network.bitcoin_network.clone(),
             stacks_network: self.network.stacks_network.clone(),
             data_handler_tx: None,
+            prometheus_monitoring_port: self.monitoring.prometheus_monitoring_port,
         }
     }
 
@@ -144,7 +150,11 @@ impl Config {
                 continue;
             }
         }
-
+        let prometheus_monitoring_port = if let Some(monitoring) = config_file.monitoring {
+            monitoring.prometheus_monitoring_port
+        } else {
+            None
+        };
         let config = Config {
             storage: StorageConfig {
                 working_dir: config_file.storage.working_dir.unwrap_or("cache".into()),
@@ -208,6 +218,9 @@ impl Config {
                 },
                 stacks_network,
                 bitcoin_network,
+            },
+            monitoring: MonitoringConfig {
+                prometheus_monitoring_port,
             },
         };
         Ok(config)
@@ -340,6 +353,9 @@ impl Config {
                 stacks_network: StacksNetwork::Devnet,
                 bitcoin_network: BitcoinNetwork::Regtest,
             },
+            monitoring: MonitoringConfig {
+                prometheus_monitoring_port: None,
+            },
         }
     }
 
@@ -371,6 +387,9 @@ impl Config {
                 stacks_network: StacksNetwork::Testnet,
                 bitcoin_network: BitcoinNetwork::Testnet,
             },
+            monitoring: MonitoringConfig {
+                prometheus_monitoring_port: None,
+            },
         }
     }
 
@@ -401,6 +420,9 @@ impl Config {
                 ),
                 stacks_network: StacksNetwork::Mainnet,
                 bitcoin_network: BitcoinNetwork::Mainnet,
+            },
+            monitoring: MonitoringConfig {
+                prometheus_monitoring_port: None,
             },
         }
     }

--- a/components/chainhook-cli/src/config/tests/mod.rs
+++ b/components/chainhook-cli/src/config/tests/mod.rs
@@ -42,13 +42,13 @@ fn config_from_file_allows_setting_disabled_fields() {
         disabled: Some(false),
     });
     generated_config_file.monitoring = Some(MonitoringConfigFile {
-        prometheus_monitoring_port: Some(1111),
+        prometheus_monitoring_port: Some(20457),
     });
     let generated_config = Config::from_config_file(generated_config_file).unwrap();
     assert!(generated_config.is_http_api_enabled());
     assert_eq!(
         generated_config.monitoring.prometheus_monitoring_port,
-        Some(1111)
+        Some(20457)
     );
 }
 

--- a/components/chainhook-cli/src/config/tests/mod.rs
+++ b/components/chainhook-cli/src/config/tests/mod.rs
@@ -1,8 +1,14 @@
 use std::path::PathBuf;
 
-use crate::config::{file::NetworkConfigMode, PredicatesApi, PredicatesApiConfig};
+use crate::config::{
+    file::{NetworkConfigMode, PredicatesApiConfigFile},
+    PredicatesApi, PredicatesApiConfig,
+};
 
-use super::{generator::generate_config, Config, ConfigFile, EventSourceConfig, PathConfig};
+use super::{
+    file::MonitoringConfigFile, generator::generate_config, Config, ConfigFile, EventSourceConfig,
+    PathConfig,
+};
 use chainhook_sdk::types::{BitcoinNetwork, StacksNetwork};
 use test_case::test_case;
 
@@ -22,6 +28,28 @@ fn config_from_file_matches_generator_for_all_networks(network: BitcoinNetwork) 
     let generated_config_file: ConfigFile = toml::from_str(&generated_config_str).unwrap();
     let generated_config = Config::from_config_file(generated_config_file).unwrap();
     assert_eq!(generated_config, from_path_config);
+}
+
+#[test]
+fn config_from_file_allows_setting_disabled_fields() {
+    let generated_config_str = generate_config(&BitcoinNetwork::Regtest);
+    let mut generated_config_file: ConfigFile = toml::from_str(&generated_config_str).unwrap();
+    // http_api and monitoring are optional, so they are disabled in generated config file
+    generated_config_file.http_api = Some(PredicatesApiConfigFile {
+        http_port: Some(0),
+        database_uri: Some(format!("")),
+        display_logs: Some(false),
+        disabled: Some(false),
+    });
+    generated_config_file.monitoring = Some(MonitoringConfigFile {
+        prometheus_monitoring_port: Some(1111),
+    });
+    let generated_config = Config::from_config_file(generated_config_file).unwrap();
+    assert!(generated_config.is_http_api_enabled());
+    assert_eq!(
+        generated_config.monitoring.prometheus_monitoring_port,
+        Some(1111)
+    );
 }
 
 #[test]

--- a/components/chainhook-cli/src/service/tests/helpers/mock_service.rs
+++ b/components/chainhook-cli/src/service/tests/helpers/mock_service.rs
@@ -172,7 +172,7 @@ pub async fn call_observer_svc(
         .map_err(|e| format!("Failed to deserialize response of {method} request to {url}: {e}",))
 }
 
-pub async fn call_ping(port: u16) -> Result<ObserverMetrics, String> {
+pub async fn call_ping(port: u16) -> Result<JsonValue, String> {
     let url = format!("http://localhost:{port}/ping");
     let res = call_observer_svc(&url, Method::GET, None).await?;
     match res.get("result") {

--- a/components/chainhook-cli/src/service/tests/mod.rs
+++ b/components/chainhook-cli/src/service/tests/mod.rs
@@ -894,8 +894,8 @@ async fn test_bitcoin_predicate_status_is_updated_with_reorg(
 async fn test_deregister_predicate(chain: Chain) {
     let (mut redis_process, working_dir, chainhook_service_port, redis_port, _, _, _) = match &chain
     {
-        Chain::Stacks => setup_stacks_chainhook_test(0, None, None).await,
-        Chain::Bitcoin => setup_bitcoin_chainhook_test(0).await,
+        Chain::Stacks => setup_stacks_chainhook_test(3, None, None).await,
+        Chain::Bitcoin => setup_bitcoin_chainhook_test(3).await,
     };
 
     let uuid = &get_random_uuid();

--- a/components/chainhook-cli/src/service/tests/observer_tests.rs
+++ b/components/chainhook-cli/src/service/tests/observer_tests.rs
@@ -50,8 +50,17 @@ async fn ping_endpoint_returns_metrics() {
         redis_process.kill().unwrap();
         panic!("test failed with error: {e}");
     });
+    let result = metrics
+        .get("stacks")
+        .unwrap()
+        .get("registered_predicates")
+        .unwrap();
+    assert_eq!(result, 1);
 
-    assert_eq!(metrics.stacks.registered_predicates, 1);
+    std::fs::remove_dir_all(&working_dir).unwrap();
+    flush_redis(redis_port);
+    redis_process.kill().unwrap();
+}
     std::fs::remove_dir_all(&working_dir).unwrap();
     flush_redis(redis_port);
     redis_process.kill().unwrap();

--- a/components/chainhook-cli/src/service/tests/observer_tests.rs
+++ b/components/chainhook-cli/src/service/tests/observer_tests.rs
@@ -88,8 +88,8 @@ async fn prometheus_endpoint_returns_encoded_metrics() {
         redis_process.kill().unwrap();
         panic!("test failed with error: {e}");
     });
-    const EXPECTED: &'static str = "# HELP stx_registered_predicates The number of Stacks predicates that have been registered by the Chainhook node.\n# TYPE stx_registered_predicates gauge\nstx_registered_predicates 1\n";
-    assert!(metrics.ends_with(EXPECTED));
+    const EXPECTED: &'static str = "# HELP chainhook_stx_registered_predicates The number of Stacks predicates that have been registered by the Chainhook node.\n# TYPE chainhook_stx_registered_predicates gauge\nchainhook_stx_registered_predicates 1\n";
+    assert!(metrics.contains(EXPECTED));
 
     std::fs::remove_dir_all(&working_dir).unwrap();
     flush_redis(redis_port);

--- a/components/chainhook-sdk/Cargo.toml
+++ b/components/chainhook-sdk/Cargo.toml
@@ -41,6 +41,7 @@ fxhash = "0.2.1"
 lazy_static = "1.4.0"
 regex = "1.9.3"
 miniscript = "11.0.0"
+prometheus = "0.13.3"
 
 [dev-dependencies]
 test-case = "3.1.0"

--- a/components/chainhook-sdk/src/lib.rs
+++ b/components/chainhook-sdk/src/lib.rs
@@ -24,6 +24,7 @@ pub use chainhook_types as types;
 
 pub mod chainhooks;
 pub mod indexer;
+pub mod monitoring;
 pub mod observer;
 pub mod utils;
 

--- a/components/chainhook-sdk/src/monitoring.rs
+++ b/components/chainhook-sdk/src/monitoring.rs
@@ -40,75 +40,75 @@ impl PrometheusMonitoring {
         let registry = Registry::new();
         let stx_highest_block_ingested = PrometheusMonitoring::create_and_register_uint64_gauge(
             &registry,
-            "stx_highest_block_ingested",
+            "chainhook_stx_highest_block_ingested",
             "The highest Stacks block ingested by the Chainhook node.",
         );
         let stx_last_reorg_timestamp = PrometheusMonitoring::create_and_register_int_gauge(
             &registry,
-            "stx_last_reorg_timestamp",
+            "chainhook_stx_last_reorg_timestamp",
             "The timestamp of the latest Stacks reorg ingested by the Chainhook node.",
         );
         let stx_last_reorg_applied_blocks = PrometheusMonitoring::create_and_register_uint64_gauge(
             &registry,
-            "stx_last_reorg_applied_blocks",
+            "chainhook_stx_last_reorg_applied_blocks",
             "The number of blocks applied to the Stacks chain as part of the latest Stacks reorg.",
         );
         let stx_last_reorg_rolled_back_blocks =
             PrometheusMonitoring::create_and_register_uint64_gauge(
                 &registry,
-                "stx_last_reorg_rolled_back_blocks",
+                "chainhook_stx_last_reorg_rolled_back_blocks",
                 "The number of blocks rolled back from the Stacks chain as part of the latest Stacks reorg.",
             );
         let stx_last_block_ingestion_time = PrometheusMonitoring::create_and_register_uint64_gauge(
             &registry,
-            "stx_last_block_ingestion_time",
+            "chainhook_stx_last_block_ingestion_time",
             "The time that the Chainhook node last ingested a Stacks block.",
         );
         let stx_registered_predicates = PrometheusMonitoring::create_and_register_uint64_gauge(
             &registry,
-            "stx_registered_predicates",
+            "chainhook_stx_registered_predicates",
             "The number of Stacks predicates that have been registered by the Chainhook node.",
         );
         let stx_deregistered_predicates = PrometheusMonitoring::create_and_register_uint64_gauge(
             &registry,
-            "stx_deregistered_predicates",
+            "chainhook_stx_deregistered_predicates",
             "The number of Stacks predicates that have been deregistered by the Chainhook node.",
         );
         let btc_highest_block_ingested = PrometheusMonitoring::create_and_register_uint64_gauge(
             &registry,
-            "btc_highest_block_ingested",
+            "chainhook_btc_highest_block_ingested",
             "The highest Bitcoin block ingested by the Chainhook node.",
         );
         let btc_last_reorg_timestamp = PrometheusMonitoring::create_and_register_int_gauge(
             &registry,
-            "btc_last_reorg_timestamp",
+            "chainhook_btc_last_reorg_timestamp",
             "The timestamp of the latest Bitcoin reorg ingested by the Chainhook node.",
         );
         let btc_last_reorg_applied_blocks =
             PrometheusMonitoring::create_and_register_uint64_gauge(
                 &registry,
-                "btc_last_reorg_applied_blocks",
+                "chainhook_btc_last_reorg_applied_blocks",
                 "The number of blocks applied to the Bitcoin chain as part of the latest Bitcoin reorg.",
             );
         let btc_last_reorg_rolled_back_blocks =
             PrometheusMonitoring::create_and_register_uint64_gauge(
                 &registry,
-                "btc_last_reorg_rolled_back_blocks",
+                "chainhook_btc_last_reorg_rolled_back_blocks",
                 "The number of blocks rolled back from the Bitcoin chain as part of the latest Bitcoin reorg.",
             );
         let btc_last_block_ingestion_time = PrometheusMonitoring::create_and_register_uint64_gauge(
             &registry,
-            "btc_last_block_ingestion_time",
+            "chainhook_btc_last_block_ingestion_time",
             "The time that the Chainhook node last ingested a Bitcoin block.",
         );
         let btc_registered_predicates = PrometheusMonitoring::create_and_register_uint64_gauge(
             &registry,
-            "btc_registered_predicates",
+            "chainhook_btc_registered_predicates",
             "The number of Bitcoin predicates that have been registered by the Chainhook node.",
         );
         let btc_deregistered_predicates = PrometheusMonitoring::create_and_register_uint64_gauge(
             &registry,
-            "btc_deregistered_predicates",
+            "chainhook_btc_deregistered_predicates",
             "The number of Bitcoin predicates that have been deregistered by the Chainhook node.",
         );
 

--- a/components/chainhook-sdk/src/monitoring.rs
+++ b/components/chainhook-sdk/src/monitoring.rs
@@ -301,7 +301,7 @@ async fn serve_req(
 }
 
 pub async fn start_serving_prometheus_metrics(port: u16, registry: Registry, ctx: Context) {
-    let addr = ([127, 0, 0, 1], port).into();
+    let addr = ([0, 0, 0, 0], port).into();
     let ctx_clone = ctx.clone();
     let make_svc = make_service_fn(|_| {
         let registry = registry.clone();

--- a/components/chainhook-sdk/src/monitoring.rs
+++ b/components/chainhook-sdk/src/monitoring.rs
@@ -1,3 +1,11 @@
+use crate::utils::Context;
+
+use hiro_system_kit::slog;
+use hyper::{
+    header::CONTENT_TYPE,
+    service::{make_service_fn, service_fn},
+    Body, Method, Request, Response, Server,
+};
 use prometheus::{
     self,
     core::{AtomicU64, GenericGauge},
@@ -243,6 +251,70 @@ impl PrometheusMonitoring {
                 "deregistered_predicates": self.stx_deregistered_predicates.get(),
             }
         })
+    }
+}
+
+async fn serve_req(
+    req: Request<Body>,
+    registry: Registry,
+    ctx: Context,
+) -> Result<Response<Body>, hyper::Error> {
+    match (req.method(), req.uri().path()) {
+        (&Method::GET, "/metrics") => {
+            ctx.try_log(|logger| {
+                slog::debug!(
+                    logger,
+                    "Prometheus monitoring: respsonding to metrics request"
+                )
+            });
+
+            let encoder = TextEncoder::new();
+            let metric_families = registry.gather();
+            let mut buffer = vec![];
+            encoder.encode(&metric_families, &mut buffer).unwrap();
+
+            let response = Response::builder()
+                .status(200)
+                .header(CONTENT_TYPE, encoder.format_type())
+                .body(Body::from(buffer))
+                .unwrap();
+
+            Ok(response)
+        }
+        (_, _) => {
+            ctx.try_log(|logger| {
+                slog::debug!(
+                    logger,
+                    "Prometheus monitoring: received request with invalid method/route: {}/{}",
+                    req.method(),
+                    req.uri().path()
+                )
+            });
+            let response = Response::builder().status(404).body(Body::empty()).unwrap();
+
+            Ok(response)
+        }
+    }
+}
+
+pub async fn start_serving_prometheus_metrics(port: u16, registry: Registry, ctx: Context) {
+    let addr = ([127, 0, 0, 1], port).into();
+    let ctx_clone = ctx.clone();
+    let make_svc = make_service_fn(|_| {
+        let registry = registry.clone();
+        let ctx_clone = ctx_clone.clone();
+        async move {
+            Ok::<_, hyper::Error>(service_fn(move |r| {
+                serve_req(r, registry.clone(), ctx_clone.clone())
+            }))
+        }
+    });
+    let serve_future = Server::bind(&addr).serve(make_svc);
+
+    ctx.try_log(|logger| slog::info!(logger, "Prometheus monitoring: listening on port {}", port));
+
+    if let Err(err) = serve_future.await {
+        ctx.try_log(|logger| slog::warn!(logger, "Prometheus monitoring: server error: {}", err));
     }
 }
 

--- a/components/chainhook-sdk/src/monitoring.rs
+++ b/components/chainhook-sdk/src/monitoring.rs
@@ -245,3 +245,100 @@ impl PrometheusMonitoring {
         })
     }
 }
+
+#[cfg(test)]
+mod test {
+    use std::{thread::sleep, time::Duration};
+
+    use super::PrometheusMonitoring;
+
+    #[test]
+    fn it_tracks_stx_predicate_registration_deregistration_with_defaults() {
+        let prometheus = PrometheusMonitoring::new();
+        assert_eq!(prometheus.stx_registered_predicates.get(), 0);
+        assert_eq!(prometheus.stx_deregistered_predicates.get(), 0);
+        prometheus.stx_metrics_set_registered_predicates(10);
+        assert_eq!(prometheus.stx_registered_predicates.get(), 10);
+        assert_eq!(prometheus.stx_deregistered_predicates.get(), 0);
+        prometheus.stx_metrics_register_predicate();
+        assert_eq!(prometheus.stx_registered_predicates.get(), 11);
+        assert_eq!(prometheus.stx_deregistered_predicates.get(), 0);
+        prometheus.stx_metrics_deregister_predicate();
+        assert_eq!(prometheus.stx_registered_predicates.get(), 10);
+        assert_eq!(prometheus.stx_deregistered_predicates.get(), 1);
+    }
+
+    #[test]
+    fn it_tracks_stx_reorgs() {
+        let prometheus = PrometheusMonitoring::new();
+        assert_eq!(prometheus.stx_last_reorg_timestamp.get(), 0);
+        assert_eq!(prometheus.stx_last_reorg_applied_blocks.get(), 0);
+        assert_eq!(prometheus.stx_last_reorg_rolled_back_blocks.get(), 0);
+        prometheus.stx_metrics_set_reorg(10000, 1, 1);
+        assert_eq!(prometheus.stx_last_reorg_timestamp.get(), 10000);
+        assert_eq!(prometheus.stx_last_reorg_applied_blocks.get(), 1);
+        assert_eq!(prometheus.stx_last_reorg_rolled_back_blocks.get(), 1);
+    }
+
+    #[test]
+    fn it_tracks_stx_block_ingestion() {
+        let prometheus = PrometheusMonitoring::new();
+        assert_eq!(prometheus.stx_highest_block_ingested.get(), 0);
+        assert_eq!(prometheus.stx_last_block_ingestion_time.get(), 0);
+        prometheus.stx_metrics_ingest_block(100);
+        assert_eq!(prometheus.stx_highest_block_ingested.get(), 100);
+        let time = prometheus.stx_last_block_ingestion_time.get();
+        assert!(time > 0);
+        // ingesting a block lower than previous tip will
+        // update ingestion time but not highest block ingested
+        sleep(Duration::new(1, 0));
+        prometheus.stx_metrics_ingest_block(99);
+        assert_eq!(prometheus.stx_highest_block_ingested.get(), 100);
+        assert!(prometheus.stx_last_block_ingestion_time.get() > time);
+    }
+
+    #[test]
+    fn it_tracks_btc_predicate_registration_deregistration_with_defaults() {
+        let prometheus = PrometheusMonitoring::new();
+        assert_eq!(prometheus.btc_registered_predicates.get(), 0);
+        assert_eq!(prometheus.btc_deregistered_predicates.get(), 0);
+        prometheus.btc_metrics_set_registered_predicates(10);
+        assert_eq!(prometheus.btc_registered_predicates.get(), 10);
+        assert_eq!(prometheus.btc_deregistered_predicates.get(), 0);
+        prometheus.btc_metrics_register_predicate();
+        assert_eq!(prometheus.btc_registered_predicates.get(), 11);
+        assert_eq!(prometheus.btc_deregistered_predicates.get(), 0);
+        prometheus.btc_metrics_deregister_predicate();
+        assert_eq!(prometheus.btc_registered_predicates.get(), 10);
+        assert_eq!(prometheus.btc_deregistered_predicates.get(), 1);
+    }
+
+    #[test]
+    fn it_tracks_btc_reorgs() {
+        let prometheus = PrometheusMonitoring::new();
+        assert_eq!(prometheus.btc_last_reorg_timestamp.get(), 0);
+        assert_eq!(prometheus.btc_last_reorg_applied_blocks.get(), 0);
+        assert_eq!(prometheus.btc_last_reorg_rolled_back_blocks.get(), 0);
+        prometheus.btc_metrics_set_reorg(10000, 1, 1);
+        assert_eq!(prometheus.btc_last_reorg_timestamp.get(), 10000);
+        assert_eq!(prometheus.btc_last_reorg_applied_blocks.get(), 1);
+        assert_eq!(prometheus.btc_last_reorg_rolled_back_blocks.get(), 1);
+    }
+
+    #[test]
+    fn it_tracks_btc_block_ingestion() {
+        let prometheus = PrometheusMonitoring::new();
+        assert_eq!(prometheus.btc_highest_block_ingested.get(), 0);
+        assert_eq!(prometheus.btc_last_block_ingestion_time.get(), 0);
+        prometheus.btc_metrics_ingest_block(100);
+        assert_eq!(prometheus.btc_highest_block_ingested.get(), 100);
+        let time = prometheus.btc_last_block_ingestion_time.get();
+        assert!(time > 0);
+        // ingesting a block lower than previous tip will
+        // update ingestion time but not highest block ingested
+        sleep(Duration::new(1, 0));
+        prometheus.btc_metrics_ingest_block(99);
+        assert_eq!(prometheus.btc_highest_block_ingested.get(), 100);
+        assert!(prometheus.btc_last_block_ingestion_time.get() > time);
+    }
+}

--- a/components/chainhook-sdk/src/monitoring.rs
+++ b/components/chainhook-sdk/src/monitoring.rs
@@ -140,6 +140,7 @@ impl PrometheusMonitoring {
         registry.register(Box::new(g.clone())).unwrap();
         g
     }
+
     pub fn create_and_register_int_gauge(registry: &Registry, name: &str, help: &str) -> IntGauge {
         let g = IntGauge::new(name, help).unwrap();
         registry.register(Box::new(g.clone())).unwrap();
@@ -147,15 +148,8 @@ impl PrometheusMonitoring {
     }
 
     pub fn stx_metrics_deregister_predicate(&self) {
-        let registered = self.stx_registered_predicates.get();
-        let deregistered = self.stx_deregistered_predicates.get();
-        println!("starting registered: {registered}. starting deregistered: {deregistered}");
-        println!("deregistering stacks predicate");
         self.stx_registered_predicates.dec();
         self.stx_deregistered_predicates.inc();
-        let registered = self.stx_registered_predicates.get();
-        let deregistered = self.stx_deregistered_predicates.get();
-        println!("ending registered: {registered}. ending deregistered: {deregistered}");
     }
 
     pub fn stx_metrics_register_predicate(&self) {

--- a/components/chainhook-sdk/src/monitoring.rs
+++ b/components/chainhook-sdk/src/monitoring.rs
@@ -1,0 +1,247 @@
+use prometheus::{
+    self,
+    core::{AtomicU64, GenericGauge},
+    Encoder, IntGauge, Registry, TextEncoder,
+};
+use rocket::serde::json::{json, Value as JsonValue};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+type UInt64Gauge = GenericGauge<AtomicU64>;
+
+#[derive(Debug, Clone)]
+pub struct PrometheusMonitoring {
+    pub stx_highest_block_ingested: UInt64Gauge,
+    pub stx_last_reorg_timestamp: IntGauge,
+    pub stx_last_reorg_applied_blocks: UInt64Gauge,
+    pub stx_last_reorg_rolled_back_blocks: UInt64Gauge,
+    pub stx_last_block_ingestion_time: UInt64Gauge,
+    pub stx_registered_predicates: UInt64Gauge,
+    pub stx_deregistered_predicates: UInt64Gauge,
+    pub btc_highest_block_ingested: UInt64Gauge,
+    pub btc_last_reorg_timestamp: IntGauge,
+    pub btc_last_reorg_applied_blocks: UInt64Gauge,
+    pub btc_last_reorg_rolled_back_blocks: UInt64Gauge,
+    pub btc_last_block_ingestion_time: UInt64Gauge,
+    pub btc_registered_predicates: UInt64Gauge,
+    pub btc_deregistered_predicates: UInt64Gauge,
+    pub registry: Registry,
+}
+
+impl PrometheusMonitoring {
+    pub fn new() -> PrometheusMonitoring {
+        let registry = Registry::new();
+        let stx_highest_block_ingested = PrometheusMonitoring::create_and_register_uint64_gauge(
+            &registry,
+            "stx_highest_block_ingested",
+            "The highest Stacks block ingested by the Chainhook node.",
+        );
+        let stx_last_reorg_timestamp = PrometheusMonitoring::create_and_register_int_gauge(
+            &registry,
+            "stx_last_reorg_timestamp",
+            "The timestamp of the latest Stacks reorg ingested by the Chainhook node.",
+        );
+        let stx_last_reorg_applied_blocks = PrometheusMonitoring::create_and_register_uint64_gauge(
+            &registry,
+            "stx_last_reorg_applied_blocks",
+            "The number of blocks applied to the Stacks chain as part of the latest Stacks reorg.",
+        );
+        let stx_last_reorg_rolled_back_blocks =
+            PrometheusMonitoring::create_and_register_uint64_gauge(
+                &registry,
+                "stx_last_reorg_rolled_back_blocks",
+                "The number of blocks rolled back from the Stacks chain as part of the latest Stacks reorg.",
+            );
+        let stx_last_block_ingestion_time = PrometheusMonitoring::create_and_register_uint64_gauge(
+            &registry,
+            "stx_last_block_ingestion_time",
+            "The time that the Chainhook node last ingested a Stacks block.",
+        );
+        let stx_registered_predicates = PrometheusMonitoring::create_and_register_uint64_gauge(
+            &registry,
+            "stx_registered_predicates",
+            "The number of Stacks predicates that have been registered by the Chainhook node.",
+        );
+        let stx_deregistered_predicates = PrometheusMonitoring::create_and_register_uint64_gauge(
+            &registry,
+            "stx_deregistered_predicates",
+            "The number of Stacks predicates that have been deregistered by the Chainhook node.",
+        );
+        let btc_highest_block_ingested = PrometheusMonitoring::create_and_register_uint64_gauge(
+            &registry,
+            "btc_highest_block_ingested",
+            "The highest Bitcoin block ingested by the Chainhook node.",
+        );
+        let btc_last_reorg_timestamp = PrometheusMonitoring::create_and_register_int_gauge(
+            &registry,
+            "btc_last_reorg_timestamp",
+            "The timestamp of the latest Bitcoin reorg ingested by the Chainhook node.",
+        );
+        let btc_last_reorg_applied_blocks =
+            PrometheusMonitoring::create_and_register_uint64_gauge(
+                &registry,
+                "btc_last_reorg_applied_blocks",
+                "The number of blocks applied to the Bitcoin chain as part of the latest Bitcoin reorg.",
+            );
+        let btc_last_reorg_rolled_back_blocks =
+            PrometheusMonitoring::create_and_register_uint64_gauge(
+                &registry,
+                "btc_last_reorg_rolled_back_blocks",
+                "The number of blocks rolled back from the Bitcoin chain as part of the latest Bitcoin reorg.",
+            );
+        let btc_last_block_ingestion_time = PrometheusMonitoring::create_and_register_uint64_gauge(
+            &registry,
+            "btc_last_block_ingestion_time",
+            "The time that the Chainhook node last ingested a Bitcoin block.",
+        );
+        let btc_registered_predicates = PrometheusMonitoring::create_and_register_uint64_gauge(
+            &registry,
+            "btc_registered_predicates",
+            "The number of Bitcoin predicates that have been registered by the Chainhook node.",
+        );
+        let btc_deregistered_predicates = PrometheusMonitoring::create_and_register_uint64_gauge(
+            &registry,
+            "btc_deregistered_predicates",
+            "The number of Bitcoin predicates that have been deregistered by the Chainhook node.",
+        );
+
+        PrometheusMonitoring {
+            stx_highest_block_ingested,
+            stx_last_reorg_timestamp,
+            stx_last_reorg_applied_blocks,
+            stx_last_reorg_rolled_back_blocks,
+            stx_last_block_ingestion_time,
+            stx_registered_predicates,
+            stx_deregistered_predicates,
+            btc_highest_block_ingested,
+            btc_last_reorg_timestamp,
+            btc_last_reorg_applied_blocks,
+            btc_last_reorg_rolled_back_blocks,
+            btc_last_block_ingestion_time,
+            btc_registered_predicates,
+            btc_deregistered_predicates,
+            registry,
+        }
+    }
+
+    pub fn create_and_register_uint64_gauge(
+        registry: &Registry,
+        name: &str,
+        help: &str,
+    ) -> UInt64Gauge {
+        let g = UInt64Gauge::new(name, help).unwrap();
+        registry.register(Box::new(g.clone())).unwrap();
+        g
+    }
+    pub fn create_and_register_int_gauge(registry: &Registry, name: &str, help: &str) -> IntGauge {
+        let g = IntGauge::new(name, help).unwrap();
+        registry.register(Box::new(g.clone())).unwrap();
+        g
+    }
+
+    pub fn stx_metrics_deregister_predicate(&self) {
+        let registered = self.stx_registered_predicates.get();
+        let deregistered = self.stx_deregistered_predicates.get();
+        println!("starting registered: {registered}. starting deregistered: {deregistered}");
+        println!("deregistering stacks predicate");
+        self.stx_registered_predicates.dec();
+        self.stx_deregistered_predicates.inc();
+        let registered = self.stx_registered_predicates.get();
+        let deregistered = self.stx_deregistered_predicates.get();
+        println!("ending registered: {registered}. ending deregistered: {deregistered}");
+    }
+
+    pub fn stx_metrics_register_predicate(&self) {
+        self.stx_registered_predicates.inc();
+    }
+    pub fn stx_metrics_set_registered_predicates(&self, registered_predicates: u64) {
+        self.stx_registered_predicates.set(registered_predicates);
+    }
+
+    pub fn stx_metrics_set_reorg(
+        &self,
+        timestamp: i64,
+        applied_blocks: u64,
+        rolled_back_blocks: u64,
+    ) {
+        self.stx_last_reorg_timestamp.set(timestamp);
+        self.stx_last_reorg_applied_blocks.set(applied_blocks);
+        self.stx_last_reorg_rolled_back_blocks
+            .set(rolled_back_blocks);
+    }
+
+    pub fn stx_metrics_ingest_block(&self, new_block_height: u64) {
+        let highest_ingested = self.stx_highest_block_ingested.get();
+        if new_block_height > highest_ingested {
+            self.stx_highest_block_ingested.set(new_block_height);
+        }
+        let time = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("Could not get current time in ms")
+            .as_secs() as u64;
+        self.stx_last_block_ingestion_time.set(time);
+    }
+
+    pub fn btc_metrics_deregister_predicate(&self) {
+        self.btc_registered_predicates.dec();
+        self.btc_deregistered_predicates.inc();
+    }
+
+    pub fn btc_metrics_register_predicate(&self) {
+        self.btc_registered_predicates.inc();
+    }
+
+    pub fn btc_metrics_set_registered_predicates(&self, registered_predicates: u64) {
+        self.btc_registered_predicates.set(registered_predicates);
+    }
+
+    pub fn btc_metrics_set_reorg(
+        &self,
+        timestamp: i64,
+        applied_blocks: u64,
+        rolled_back_blocks: u64,
+    ) {
+        self.btc_last_reorg_timestamp.set(timestamp);
+        self.btc_last_reorg_applied_blocks.set(applied_blocks);
+        self.btc_last_reorg_rolled_back_blocks
+            .set(rolled_back_blocks);
+    }
+
+    pub fn btc_metrics_ingest_block(&self, new_block_height: u64) {
+        let highest_ingested = self.btc_highest_block_ingested.get();
+        if new_block_height > highest_ingested {
+            self.btc_highest_block_ingested.set(new_block_height);
+        }
+        let time = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("Could not get current time in ms")
+            .as_secs() as u64;
+        self.btc_last_block_ingestion_time.set(time);
+    }
+
+    pub fn get_metrics(&self) -> JsonValue {
+        json!({
+            "bitcoin": {
+                "tip_height": self.btc_highest_block_ingested.get(),
+                "last_block_ingestion_at": self.btc_last_block_ingestion_time.get(),
+                "last_reorg": {
+                    "timestamp": self.btc_last_reorg_timestamp.get(),
+                    "applied_blocks": self.btc_last_reorg_applied_blocks.get(),
+                    "rolled_back_blocks": self.btc_last_reorg_rolled_back_blocks.get(),
+                },
+                "registered_predicates": self.btc_registered_predicates.get(),
+                "deregistered_predicates": self.btc_deregistered_predicates.get(),
+            },
+            "stacks": {
+                "tip_height": self.stx_highest_block_ingested.get(),
+                "last_block_ingestion_at": self.stx_last_block_ingestion_time.get(),
+                "last_reorg": {
+                    "timestamp": self.stx_last_reorg_timestamp.get(),
+                    "applied_blocks": self.stx_last_reorg_applied_blocks.get(),
+                    "rolled_back_blocks": self.stx_last_reorg_rolled_back_blocks.get(),
+                },
+                "registered_predicates": self.stx_registered_predicates.get(),
+                "deregistered_predicates": self.stx_deregistered_predicates.get(),
+            }
+        })
+    }
+}

--- a/components/chainhook-sdk/src/observer/http.rs
+++ b/components/chainhook-sdk/src/observer/http.rs
@@ -2,6 +2,7 @@ use crate::indexer::bitcoin::{
     build_http_client, download_and_parse_block_with_retry, NewBitcoinBlock,
 };
 use crate::indexer::{self, Indexer};
+use crate::monitoring::PrometheusMonitoring;
 use crate::utils::Context;
 use hiro_system_kit::slog;
 use rocket::serde::json::{json, Json, Value as JsonValue};
@@ -10,19 +11,20 @@ use std::sync::mpsc::Sender;
 use std::sync::{Arc, Mutex, RwLock};
 
 use super::{
-    BitcoinConfig, BitcoinRPCRequest, MempoolAdmissionData, ObserverCommand, ObserverMetrics,
+    BitcoinConfig, BitcoinRPCRequest, MempoolAdmissionData, ObserverCommand,
     StacksChainMempoolEvent,
 };
 
 #[rocket::get("/ping", format = "application/json")]
 pub fn handle_ping(
     ctx: &State<Context>,
-    metrics_rw_lock: &State<Arc<RwLock<ObserverMetrics>>>,
+    prometheus_monitoring: &State<PrometheusMonitoring>,
 ) -> Json<JsonValue> {
     ctx.try_log(|logger| slog::info!(logger, "GET /ping"));
+
     Json(json!({
         "status": 200,
-        "result": metrics_rw_lock.inner(),
+        "result": prometheus_monitoring.get_metrics(),
     }))
 }
 

--- a/components/chainhook-sdk/src/observer/mod.rs
+++ b/components/chainhook-sdk/src/observer/mod.rs
@@ -137,6 +137,63 @@ impl EventObserverConfig {
             _ => unreachable!(),
         }
     }
+
+    /// Helper to allow overriding some default fields in creating a new EventObserverConfig.
+    ///
+    /// *Note: This is used by external crates, so it should not be removed, even if not used internally by Chainhook.*
+    pub fn new_using_overrides(
+        overrides: Option<&EventObserverConfigOverrides>,
+    ) -> Result<EventObserverConfig, String> {
+        let bitcoin_network =
+            if let Some(network) = overrides.and_then(|c| c.bitcoin_network.as_ref()) {
+                BitcoinNetwork::from_str(network)?
+            } else {
+                BitcoinNetwork::Regtest
+            };
+
+        let stacks_network =
+            if let Some(network) = overrides.and_then(|c| c.stacks_network.as_ref()) {
+                StacksNetwork::from_str(network)?
+            } else {
+                StacksNetwork::Devnet
+            };
+
+        let config = EventObserverConfig {
+            bitcoin_rpc_proxy_enabled: false,
+            chainhook_config: None,
+            ingestion_port: overrides
+                .and_then(|c| c.ingestion_port)
+                .unwrap_or(DEFAULT_INGESTION_PORT),
+            bitcoind_rpc_username: overrides
+                .and_then(|c| c.bitcoind_rpc_username.clone())
+                .unwrap_or("devnet".to_string()),
+            bitcoind_rpc_password: overrides
+                .and_then(|c| c.bitcoind_rpc_password.clone())
+                .unwrap_or("devnet".to_string()),
+            bitcoind_rpc_url: overrides
+                .and_then(|c| c.bitcoind_rpc_url.clone())
+                .unwrap_or("http://localhost:18443".to_string()),
+            bitcoin_block_signaling: overrides
+                .and_then(|c| c.bitcoind_zmq_url.as_ref())
+                .map(|url| BitcoinBlockSignaling::ZeroMQ(url.clone()))
+                .unwrap_or(BitcoinBlockSignaling::Stacks(
+                    StacksNodeConfig::default_localhost(
+                        overrides
+                            .and_then(|c| c.ingestion_port)
+                            .unwrap_or(DEFAULT_INGESTION_PORT),
+                    ),
+                )),
+            display_logs: overrides.and_then(|c| c.display_logs).unwrap_or(false),
+            cache_path: overrides
+                .and_then(|c| c.cache_path.clone())
+                .unwrap_or("cache".to_string()),
+            bitcoin_network,
+            stacks_network,
+            data_handler_tx: None,
+            prometheus_monitoring_port: None,
+        };
+        Ok(config)
+    }
 }
 
 #[derive(Deserialize, Debug)]

--- a/components/chainhook-sdk/src/observer/mod.rs
+++ b/components/chainhook-sdk/src/observer/mod.rs
@@ -137,59 +137,6 @@ impl EventObserverConfig {
             _ => unreachable!(),
         }
     }
-
-    pub fn new_using_overrides(
-        overrides: Option<&EventObserverConfigOverrides>,
-    ) -> Result<EventObserverConfig, String> {
-        let bitcoin_network =
-            if let Some(network) = overrides.and_then(|c| c.bitcoin_network.as_ref()) {
-                BitcoinNetwork::from_str(network)?
-            } else {
-                BitcoinNetwork::Regtest
-            };
-
-        let stacks_network =
-            if let Some(network) = overrides.and_then(|c| c.stacks_network.as_ref()) {
-                StacksNetwork::from_str(network)?
-            } else {
-                StacksNetwork::Devnet
-            };
-
-        let config = EventObserverConfig {
-            bitcoin_rpc_proxy_enabled: false,
-            chainhook_config: None,
-            ingestion_port: overrides
-                .and_then(|c| c.ingestion_port)
-                .unwrap_or(DEFAULT_INGESTION_PORT),
-            bitcoind_rpc_username: overrides
-                .and_then(|c| c.bitcoind_rpc_username.clone())
-                .unwrap_or("devnet".to_string()),
-            bitcoind_rpc_password: overrides
-                .and_then(|c| c.bitcoind_rpc_password.clone())
-                .unwrap_or("devnet".to_string()),
-            bitcoind_rpc_url: overrides
-                .and_then(|c| c.bitcoind_rpc_url.clone())
-                .unwrap_or("http://localhost:18443".to_string()),
-            bitcoin_block_signaling: overrides
-                .and_then(|c| c.bitcoind_zmq_url.as_ref())
-                .map(|url| BitcoinBlockSignaling::ZeroMQ(url.clone()))
-                .unwrap_or(BitcoinBlockSignaling::Stacks(
-                    StacksNodeConfig::default_localhost(
-                        overrides
-                            .and_then(|c| c.ingestion_port)
-                            .unwrap_or(DEFAULT_INGESTION_PORT),
-                    ),
-                )),
-            display_logs: overrides.and_then(|c| c.display_logs).unwrap_or(false),
-            cache_path: overrides
-                .and_then(|c| c.cache_path.clone())
-                .unwrap_or("cache".to_string()),
-            bitcoin_network,
-            stacks_network,
-            data_handler_tx: None,
-        };
-        Ok(config)
-    }
 }
 
 #[derive(Deserialize, Debug)]

--- a/components/chainhook-sdk/src/observer/mod.rs
+++ b/components/chainhook-sdk/src/observer/mod.rs
@@ -79,6 +79,7 @@ pub struct EventObserverConfig {
     pub bitcoin_network: BitcoinNetwork,
     pub stacks_network: StacksNetwork,
     pub data_handler_tx: Option<crossbeam_channel::Sender<DataHandlerEvent>>,
+    pub prometheus_monitoring_port: Option<u16>,
 }
 
 #[derive(Deserialize, Debug, Clone)]

--- a/components/chainhook-sdk/src/observer/tests/mod.rs
+++ b/components/chainhook-sdk/src/observer/tests/mod.rs
@@ -45,6 +45,7 @@ fn generate_test_config() -> (EventObserverConfig, ChainhookStore) {
         bitcoin_network: BitcoinNetwork::Regtest,
         stacks_network: StacksNetwork::Devnet,
         data_handler_tx: None,
+        prometheus_monitoring_port: None,
     };
     let predicates = ChainhookConfig::new();
     let chainhook_store = ChainhookStore { predicates };

--- a/components/chainhook-sdk/src/observer/tests/mod.rs
+++ b/components/chainhook-sdk/src/observer/tests/mod.rs
@@ -11,9 +11,10 @@ use crate::indexer::tests::helpers::transactions::generate_test_tx_bitcoin_p2pkh
 use crate::indexer::tests::helpers::{
     accounts, bitcoin_blocks, stacks_blocks, transactions::generate_test_tx_stacks_contract_call,
 };
+use crate::monitoring::PrometheusMonitoring;
 use crate::observer::{
     start_observer_commands_handler, ChainhookStore, EventObserverConfig, ObserverCommand,
-    ObserverMetrics, ObserverSidecar,
+    ObserverSidecar,
 };
 use crate::utils::{AbstractBlock, Context};
 use chainhook_types::{
@@ -25,7 +26,6 @@ use chainhook_types::{
 use hiro_system_kit;
 use std::collections::BTreeMap;
 use std::sync::mpsc::{channel, Sender};
-use std::sync::{Arc, RwLock};
 
 use super::{ObserverEvent, DEFAULT_INGESTION_PORT};
 
@@ -267,64 +267,48 @@ fn assert_stacks_chain_event(observer_events_rx: &crossbeam_channel::Receiver<Ob
 }
 
 fn assert_observer_metrics_stacks_registered_predicates(
-    observer_metrics_rw_lock: &Arc<RwLock<ObserverMetrics>>,
-    expected_count: usize,
+    prometheus_monitoring: &PrometheusMonitoring,
+    expected_count: u64,
 ) {
     assert_eq!(
         expected_count,
-        observer_metrics_rw_lock
-            .read()
-            .unwrap()
-            .stacks
-            .registered_predicates,
+        prometheus_monitoring.stx_registered_predicates.get(),
         "expected {} registered stacks hooks",
         expected_count
     );
 }
 
 fn assert_observer_metrics_stacks_deregistered_predicates(
-    observer_metrics_rw_lock: &Arc<RwLock<ObserverMetrics>>,
-    expected_count: usize,
+    prometheus_monitoring: &PrometheusMonitoring,
+    expected_count: u64,
 ) {
     assert_eq!(
         expected_count,
-        observer_metrics_rw_lock
-            .read()
-            .unwrap()
-            .stacks
-            .deregistered_predicates,
+        prometheus_monitoring.stx_deregistered_predicates.get(),
         "expected {} deregistered stacks hooks",
         expected_count
     );
 }
 
 fn assert_observer_metrics_bitcoin_registered_predicates(
-    observer_metrics_rw_lock: &Arc<RwLock<ObserverMetrics>>,
-    expected_count: usize,
+    prometheus_monitoring: &PrometheusMonitoring,
+    expected_count: u64,
 ) {
     assert_eq!(
         expected_count,
-        observer_metrics_rw_lock
-            .read()
-            .unwrap()
-            .bitcoin
-            .registered_predicates,
+        prometheus_monitoring.btc_registered_predicates.get(),
         "expected {} registered bitcoin hooks",
         expected_count
     );
 }
 
 fn assert_observer_metrics_bitcoin_deregistered_predicates(
-    observer_metrics_rw_lock: &Arc<RwLock<ObserverMetrics>>,
-    expected_count: usize,
+    prometheus_monitoring: &PrometheusMonitoring,
+    expected_count: u64,
 ) {
     assert_eq!(
         expected_count,
-        observer_metrics_rw_lock
-            .read()
-            .unwrap()
-            .bitcoin
-            .deregistered_predicates,
+        prometheus_monitoring.btc_deregistered_predicates.get(),
         "expected {} deregistered bitcoin hooks",
         expected_count
     );
@@ -365,8 +349,8 @@ fn generate_and_register_new_ordinals_chainhook(
 fn test_stacks_chainhook_register_deregister() {
     let (observer_commands_tx, observer_commands_rx) = channel();
     let (observer_events_tx, observer_events_rx) = crossbeam_channel::unbounded();
-    let observer_metrics_rw_lock = Arc::new(RwLock::new(ObserverMetrics::default()));
-    let observer_metrics_rw_lock_moved = observer_metrics_rw_lock.clone();
+    let prometheus_monitoring = PrometheusMonitoring::new();
+    let prometheus_monitoring_moved = prometheus_monitoring.clone();
 
     let handle = std::thread::spawn(move || {
         let (config, chainhook_store) = generate_test_config();
@@ -376,7 +360,7 @@ fn test_stacks_chainhook_register_deregister() {
             observer_commands_rx,
             Some(observer_events_tx),
             None,
-            observer_metrics_rw_lock_moved,
+            prometheus_monitoring_moved,
             None,
             Context::empty(),
         ));
@@ -392,7 +376,7 @@ fn test_stacks_chainhook_register_deregister() {
     );
 
     // registering stacks chainhook should increment the observer_metric's registered stacks hooks
-    assert_observer_metrics_stacks_registered_predicates(&observer_metrics_rw_lock, 1);
+    assert_observer_metrics_stacks_registered_predicates(&prometheus_monitoring, 1);
 
     // Simulate a block that does not include a trigger
     let transactions = vec![generate_test_tx_stacks_contract_call(
@@ -523,9 +507,9 @@ fn test_stacks_chainhook_register_deregister() {
     });
 
     // deregistering stacks chainhook should decrement the observer_metric's registered stacks hooks
-    assert_observer_metrics_stacks_registered_predicates(&observer_metrics_rw_lock, 0);
+    assert_observer_metrics_stacks_registered_predicates(&prometheus_monitoring, 0);
     // and increment the deregistered hooks
-    assert_observer_metrics_stacks_deregistered_predicates(&observer_metrics_rw_lock, 1);
+    assert_observer_metrics_stacks_deregistered_predicates(&prometheus_monitoring, 1);
 
     // Simulate a block that does not include a trigger
     let transactions = vec![generate_test_tx_stacks_contract_call(
@@ -567,6 +551,8 @@ fn test_stacks_chainhook_register_deregister() {
     // Should propagate block
     assert_stacks_chain_event(&observer_events_rx);
 
+    let thing = &prometheus_monitoring.registry.gather();
+    println!("gathered, {:?}", thing);
     let _ = observer_commands_tx.send(ObserverCommand::Terminate);
     handle.join().expect("unable to terminate thread");
 }
@@ -575,8 +561,8 @@ fn test_stacks_chainhook_register_deregister() {
 fn test_stacks_chainhook_auto_deregister() {
     let (observer_commands_tx, observer_commands_rx) = channel();
     let (observer_events_tx, observer_events_rx) = crossbeam_channel::unbounded();
-    let observer_metrics_rw_lock = Arc::new(RwLock::new(ObserverMetrics::default()));
-    let observer_metrics_rw_lock_moved = observer_metrics_rw_lock.clone();
+    let prometheus_monitoring = PrometheusMonitoring::new();
+    let prometheus_monitoring_moved = prometheus_monitoring.clone();
 
     let handle = std::thread::spawn(move || {
         let (config, chainhook_store) = generate_test_config();
@@ -586,7 +572,7 @@ fn test_stacks_chainhook_auto_deregister() {
             observer_commands_rx,
             Some(observer_events_tx),
             None,
-            observer_metrics_rw_lock_moved,
+            prometheus_monitoring_moved,
             None,
             Context::empty(),
         ));
@@ -616,7 +602,7 @@ fn test_stacks_chainhook_auto_deregister() {
         _ => false,
     });
     // registering stacks chainhook should increment the observer_metric's registered stacks hooks
-    assert_observer_metrics_stacks_registered_predicates(&observer_metrics_rw_lock, 1);
+    assert_observer_metrics_stacks_registered_predicates(&prometheus_monitoring, 1);
 
     // Simulate a block that does not include a trigger
     let transactions = vec![generate_test_tx_stacks_contract_call(
@@ -712,9 +698,9 @@ fn test_stacks_chainhook_auto_deregister() {
     });
 
     // deregistering stacks chainhook should decrement the observer_metric's registered stacks hooks
-    assert_observer_metrics_stacks_registered_predicates(&observer_metrics_rw_lock, 0);
+    assert_observer_metrics_stacks_registered_predicates(&prometheus_monitoring, 0);
     // and increment the deregistered hooks
-    assert_observer_metrics_stacks_deregistered_predicates(&observer_metrics_rw_lock, 1);
+    assert_observer_metrics_stacks_deregistered_predicates(&prometheus_monitoring, 1);
 
     // Should propagate block
     assert_stacks_chain_event(&observer_events_rx);
@@ -727,8 +713,8 @@ fn test_stacks_chainhook_auto_deregister() {
 fn test_bitcoin_chainhook_register_deregister() {
     let (observer_commands_tx, observer_commands_rx) = channel();
     let (observer_events_tx, observer_events_rx) = crossbeam_channel::unbounded();
-    let observer_metrics_rw_lock = Arc::new(RwLock::new(ObserverMetrics::default()));
-    let observer_metrics_rw_lock_moved = observer_metrics_rw_lock.clone();
+    let prometheus_monitoring = PrometheusMonitoring::new();
+    let prometheus_monitoring_moved = prometheus_monitoring.clone();
 
     let handle = std::thread::spawn(move || {
         let (config, chainhook_store) = generate_test_config();
@@ -738,7 +724,7 @@ fn test_bitcoin_chainhook_register_deregister() {
             observer_commands_rx,
             Some(observer_events_tx),
             None,
-            observer_metrics_rw_lock_moved,
+            prometheus_monitoring_moved,
             None,
             Context::empty(),
         ));
@@ -754,7 +740,7 @@ fn test_bitcoin_chainhook_register_deregister() {
     );
 
     // registering bitcoin chainhook should increment the observer_metric's registered bitcoin hooks
-    assert_observer_metrics_bitcoin_registered_predicates(&observer_metrics_rw_lock, 1);
+    assert_observer_metrics_bitcoin_registered_predicates(&prometheus_monitoring, 1);
 
     // Simulate a block that does not include a trigger (wallet_1 to wallet_3)
     let transactions = vec![generate_test_tx_bitcoin_p2pkh_transfer(
@@ -881,9 +867,9 @@ fn test_bitcoin_chainhook_register_deregister() {
     });
 
     // deregistering bitcoin chainhook should decrement the observer_metric's registered bitcoin hooks
-    assert_observer_metrics_bitcoin_registered_predicates(&observer_metrics_rw_lock, 0);
+    assert_observer_metrics_bitcoin_registered_predicates(&prometheus_monitoring, 0);
     // and increment the deregistered hooks
-    assert_observer_metrics_bitcoin_deregistered_predicates(&observer_metrics_rw_lock, 1);
+    assert_observer_metrics_bitcoin_deregistered_predicates(&prometheus_monitoring, 1);
 
     // Simulate a block that does not include a trigger
     let transactions = vec![generate_test_tx_bitcoin_p2pkh_transfer(
@@ -944,8 +930,8 @@ fn test_bitcoin_chainhook_register_deregister() {
 fn test_bitcoin_chainhook_auto_deregister() {
     let (observer_commands_tx, observer_commands_rx) = channel();
     let (observer_events_tx, observer_events_rx) = crossbeam_channel::unbounded();
-    let observer_metrics_rw_lock = Arc::new(RwLock::new(ObserverMetrics::default()));
-    let observer_metrics_rw_lock_moved = observer_metrics_rw_lock.clone();
+    let prometheus_monitoring = PrometheusMonitoring::new();
+    let prometheus_monitoring_moved = prometheus_monitoring.clone();
 
     let handle = std::thread::spawn(move || {
         let (config, chainhook_store) = generate_test_config();
@@ -955,7 +941,7 @@ fn test_bitcoin_chainhook_auto_deregister() {
             observer_commands_rx,
             Some(observer_events_tx),
             None,
-            observer_metrics_rw_lock_moved,
+            prometheus_monitoring_moved,
             None,
             Context::empty(),
         ));
@@ -971,7 +957,7 @@ fn test_bitcoin_chainhook_auto_deregister() {
     );
 
     // registering bitcoin chainhook should increment the observer_metric's registered bitcoin hooks
-    assert_observer_metrics_bitcoin_registered_predicates(&observer_metrics_rw_lock, 1);
+    assert_observer_metrics_bitcoin_registered_predicates(&prometheus_monitoring, 1);
 
     // Simulate a block that does not include a trigger (wallet_1 to wallet_3)
     let transactions = vec![generate_test_tx_bitcoin_p2pkh_transfer(
@@ -1089,9 +1075,9 @@ fn test_bitcoin_chainhook_auto_deregister() {
     });
 
     // deregistering bitcoin chainhook should decrement the observer_metric's registered bitcoin hooks
-    assert_observer_metrics_bitcoin_registered_predicates(&observer_metrics_rw_lock, 0);
+    assert_observer_metrics_bitcoin_registered_predicates(&prometheus_monitoring, 0);
     // and increment the deregistered hooks
-    assert_observer_metrics_bitcoin_deregistered_predicates(&observer_metrics_rw_lock, 1);
+    assert_observer_metrics_bitcoin_deregistered_predicates(&prometheus_monitoring, 1);
 
     // Should propagate block
     assert!(match observer_events_rx.recv() {
@@ -1112,8 +1098,6 @@ fn test_bitcoin_chainhook_through_reorg() {
     let (block_pre_processor_out_tx, block_pre_processor_out_rx) = crossbeam_channel::unbounded();
 
     let (observer_events_tx, observer_events_rx) = crossbeam_channel::unbounded();
-    let observer_metrics_rw_lock = Arc::new(RwLock::new(ObserverMetrics::default()));
-    let observer_metrics_rw_lock_moved = observer_metrics_rw_lock.clone();
 
     let empty_ctx = Context::empty();
 
@@ -1121,6 +1105,8 @@ fn test_bitcoin_chainhook_through_reorg() {
         bitcoin_blocks_mutator: Some((block_pre_processor_in_tx, block_pre_processor_out_rx)),
         bitcoin_chain_event_notifier: None,
     };
+    let prometheus_monitoring = PrometheusMonitoring::new();
+    let prometheus_monitoring_moved = prometheus_monitoring.clone();
 
     let handle = std::thread::spawn(move || {
         let (config, chainhook_store) = generate_test_config();
@@ -1130,7 +1116,7 @@ fn test_bitcoin_chainhook_through_reorg() {
             observer_commands_rx,
             Some(observer_events_tx),
             None,
-            observer_metrics_rw_lock_moved,
+            prometheus_monitoring_moved,
             Some(observer_sidecar),
             Context::empty(),
         ));
@@ -1185,14 +1171,8 @@ fn test_bitcoin_chainhook_through_reorg() {
         generate_and_register_new_ordinals_chainhook(&observer_commands_tx, &observer_events_rx, 1);
 
     // registering bitcoin chainhook should increment the observer_metric's registered bitcoin hooks
-    assert_eq!(
-        1,
-        observer_metrics_rw_lock
-            .read()
-            .unwrap()
-            .bitcoin
-            .registered_predicates
-    );
+
+    assert_observer_metrics_bitcoin_registered_predicates(&prometheus_monitoring, 1);
 
     // Simulate a block that does not include a trigger (wallet_1 to wallet_3)
     let transactions = vec![generate_test_tx_bitcoin_p2pkh_transfer(


### PR DESCRIPTION
### Description

To enable improved alerts on downtime for Hiro's hosted Chainhook service, we need Chainhook to provide metrics that can be ingested by Prometheus. This PR changes some how we track our metrics (that are served over the `/ping` endpoint of the observer) to enable Prometheus compatibility, and adds a flag to optionally start a server to supply metrics to a Prometheus client.


### Example

Starting chainhook with the `--prometheus-port XXXX` flag now enables a service that can supply Prometheus metrics at `localhost:XXXX/metrics`.

If using a config file, this option can be specified via:
```yaml
[monitoring]
prometheus_monitoring_port = XXXX
```

Chainhook will behave as usual with this flag ommitted - metrics can still be retrieved via the observer's `/ping` endpoint, but they will not be formatted for ingestion by a Prometheus client.

---

### Checklist

- [X] All tests pass
- [X] Tests added in this PR (if applicable)

Fixes #474, addresses #466 
