### PR TITLE
fix: reduce memory usage in archive file ingestion 

### DIFF
--- a/components/chainhook-cli/src/archive/mod.rs
+++ b/components/chainhook-cli/src/archive/mod.rs
@@ -175,6 +175,7 @@ pub async fn download_stacks_dataset_if_required(config: &mut Config, ctx: &Cont
                     std::process::exit(1);
                 }
             }
+            info!(ctx.expect_logger(), "Successfully downloaded tsv file.");
             config.add_local_stacks_tsv_source(&tsv_file_path);
         }
         true

--- a/components/chainhook-cli/src/archive/mod.rs
+++ b/components/chainhook-cli/src/archive/mod.rs
@@ -175,7 +175,7 @@ pub async fn download_stacks_dataset_if_required(config: &mut Config, ctx: &Cont
                     std::process::exit(1);
                 }
             }
-            info!(ctx.expect_logger(), "Successfully downloaded tsv file.");
+            info!(ctx.expect_logger(), "Successfully downloaded tsv file");
             config.add_local_stacks_tsv_source(&tsv_file_path);
         }
         true

--- a/components/chainhook-cli/src/scan/stacks.rs
+++ b/components/chainhook-cli/src/scan/stacks.rs
@@ -69,9 +69,13 @@ pub async fn get_canonical_fork_from_tsv(
     let (record_tx, record_rx) = std::sync::mpsc::channel();
 
     let start_block = 0;
-
+    let ctx_moved = ctx.clone();
     let parsing_handle = hiro_system_kit::thread_named("Stacks chainstate CSV parsing")
         .spawn(move || {
+            info!(
+                ctx_moved.expect_logger(),
+                "Starting Stacks chainstate ingestion."
+            );
             let mut reader_builder = csv::ReaderBuilder::default()
                 .has_headers(false)
                 .delimiter(b'\t')
@@ -92,6 +96,10 @@ pub async fn get_canonical_fork_from_tsv(
                 };
             }
             let _ = record_tx.send(None);
+            info!(
+                ctx_moved.expect_logger(),
+                "Completed Stacks chainstate ingestion."
+            );
         })
         .expect("unable to spawn thread");
 

--- a/components/chainhook-cli/src/storage/mod.rs
+++ b/components/chainhook-cli/src/storage/mod.rs
@@ -91,12 +91,15 @@ pub fn insert_entry_in_stacks_blocks(block: &StacksBlockData, stacks_db_rw: &DB,
     stacks_db_rw
         .put(&key, &block_bytes.to_string().as_bytes())
         .expect("unable to insert blocks");
-    stacks_db_rw
-        .put(
-            get_last_confirmed_insert_key(),
-            block.block_identifier.index.to_be_bytes(),
-        )
-        .expect("unable to insert metadata");
+    let previous_last_inserted = get_last_block_height_inserted(stacks_db_rw, _ctx).unwrap_or(0);
+    if block.block_identifier.index > previous_last_inserted {
+        stacks_db_rw
+            .put(
+                get_last_confirmed_insert_key(),
+                block.block_identifier.index.to_be_bytes(),
+            )
+            .expect("unable to insert metadata");
+    }
 }
 
 pub fn insert_unconfirmed_entry_in_stacks_blocks(


### PR DESCRIPTION
Previously, when parsing and archive tsv to determine the canonical fork, we would always start at block 0, even if there was a rocksdb instance containing stacks chaindata. The entire fork was loaded in memory and inserted.

Now, we start at the latest confirmed chaintip for this process, which greatly reduces the memory footprint on subsequent startups of the Chainhook service. Note: an initial run of the Chainhook service can still use significant memory.