### PR TITLE
fix: remove early return for event evaluation

### DIFF
--- a/components/chainhook-sdk/src/chainhooks/stacks/mod.rs
+++ b/components/chainhook-sdk/src/chainhooks/stacks/mod.rs
@@ -375,29 +375,34 @@ pub fn evaluate_stacks_predicate_on_transaction<'a>(
             let expecting_transfer = expected_event.actions.contains(&"transfer".to_string());
             let expecting_burn = expected_event.actions.contains(&"burn".to_string());
 
-            let mut is_match;
             for event in transaction.metadata.receipt.events.iter() {
                 match (event, expecting_mint, expecting_transfer, expecting_burn) {
                     (StacksTransactionEvent::FTMintEvent(ft_event), true, _, _) => {
-                        is_match = ft_event
+                        if ft_event
                             .asset_class_identifier
-                            .eq(&expected_event.asset_identifier);
+                            .eq(&expected_event.asset_identifier)
+                        {
+                            return true;
+                        }
                     }
                     (StacksTransactionEvent::FTTransferEvent(ft_event), _, true, _) => {
-                        is_match = ft_event
+                        if ft_event
                             .asset_class_identifier
-                            .eq(&expected_event.asset_identifier);
+                            .eq(&expected_event.asset_identifier)
+                        {
+                            return true;
+                        }
                     }
                     (StacksTransactionEvent::FTBurnEvent(ft_event), _, _, true) => {
-                        is_match = ft_event
+                        if ft_event
                             .asset_class_identifier
-                            .eq(&expected_event.asset_identifier);
+                            .eq(&expected_event.asset_identifier)
+                        {
+                            return true;
+                        }
                     }
                     _ => continue,
                 }
-                if is_match {
-                    return true;
-                };
             }
             false
         }
@@ -406,29 +411,34 @@ pub fn evaluate_stacks_predicate_on_transaction<'a>(
             let expecting_transfer = expected_event.actions.contains(&"transfer".to_string());
             let expecting_burn = expected_event.actions.contains(&"burn".to_string());
 
-            let mut is_match;
             for event in transaction.metadata.receipt.events.iter() {
                 match (event, expecting_mint, expecting_transfer, expecting_burn) {
                     (StacksTransactionEvent::NFTMintEvent(nft_event), true, _, _) => {
-                        is_match = nft_event
+                        if nft_event
                             .asset_class_identifier
-                            .eq(&expected_event.asset_identifier);
+                            .eq(&expected_event.asset_identifier)
+                        {
+                            return true;
+                        }
                     }
                     (StacksTransactionEvent::NFTTransferEvent(nft_event), _, true, _) => {
-                        is_match = nft_event
+                        if nft_event
                             .asset_class_identifier
-                            .eq(&expected_event.asset_identifier);
+                            .eq(&expected_event.asset_identifier)
+                        {
+                            return true;
+                        }
                     }
                     (StacksTransactionEvent::NFTBurnEvent(nft_event), _, _, true) => {
-                        is_match = nft_event
+                        if nft_event
                             .asset_class_identifier
-                            .eq(&expected_event.asset_identifier);
+                            .eq(&expected_event.asset_identifier)
+                        {
+                            return true;
+                        }
                     }
                     _ => continue,
                 }
-                if is_match {
-                    return true;
-                };
             }
             false
         }

--- a/components/chainhook-sdk/src/chainhooks/stacks/mod.rs
+++ b/components/chainhook-sdk/src/chainhooks/stacks/mod.rs
@@ -375,25 +375,29 @@ pub fn evaluate_stacks_predicate_on_transaction<'a>(
             let expecting_transfer = expected_event.actions.contains(&"transfer".to_string());
             let expecting_burn = expected_event.actions.contains(&"burn".to_string());
 
+            let mut is_match;
             for event in transaction.metadata.receipt.events.iter() {
                 match (event, expecting_mint, expecting_transfer, expecting_burn) {
                     (StacksTransactionEvent::FTMintEvent(ft_event), true, _, _) => {
-                        return ft_event
+                        is_match = ft_event
                             .asset_class_identifier
-                            .eq(&expected_event.asset_identifier)
+                            .eq(&expected_event.asset_identifier);
                     }
                     (StacksTransactionEvent::FTTransferEvent(ft_event), _, true, _) => {
-                        return ft_event
+                        is_match = ft_event
                             .asset_class_identifier
-                            .eq(&expected_event.asset_identifier)
+                            .eq(&expected_event.asset_identifier);
                     }
                     (StacksTransactionEvent::FTBurnEvent(ft_event), _, _, true) => {
-                        return ft_event
+                        is_match = ft_event
                             .asset_class_identifier
-                            .eq(&expected_event.asset_identifier)
+                            .eq(&expected_event.asset_identifier);
                     }
                     _ => continue,
                 }
+                if is_match {
+                    return true;
+                };
             }
             false
         }
@@ -401,25 +405,30 @@ pub fn evaluate_stacks_predicate_on_transaction<'a>(
             let expecting_mint = expected_event.actions.contains(&"mint".to_string());
             let expecting_transfer = expected_event.actions.contains(&"transfer".to_string());
             let expecting_burn = expected_event.actions.contains(&"burn".to_string());
+
+            let mut is_match;
             for event in transaction.metadata.receipt.events.iter() {
                 match (event, expecting_mint, expecting_transfer, expecting_burn) {
                     (StacksTransactionEvent::NFTMintEvent(nft_event), true, _, _) => {
-                        return nft_event
+                        is_match = nft_event
                             .asset_class_identifier
-                            .eq(&expected_event.asset_identifier)
+                            .eq(&expected_event.asset_identifier);
                     }
                     (StacksTransactionEvent::NFTTransferEvent(nft_event), _, true, _) => {
-                        return nft_event
+                        is_match = nft_event
                             .asset_class_identifier
-                            .eq(&expected_event.asset_identifier)
+                            .eq(&expected_event.asset_identifier);
                     }
                     (StacksTransactionEvent::NFTBurnEvent(nft_event), _, _, true) => {
-                        return nft_event
+                        is_match = nft_event
                             .asset_class_identifier
-                            .eq(&expected_event.asset_identifier)
+                            .eq(&expected_event.asset_identifier);
                     }
                     _ => continue,
                 }
+                if is_match {
+                    return true;
+                };
             }
             false
         }

--- a/components/chainhook-sdk/src/chainhooks/tests/mod.rs
+++ b/components/chainhook-sdk/src/chainhooks/tests/mod.rs
@@ -49,6 +49,25 @@ pub mod fixtures;
     "FtEvent predicates match transfer event"
 )]
 #[test_case(
+    vec![vec![StacksTransactionEvent::FTTransferEvent(chainhook_types::FTTransferEventData {
+        sender: "".to_string(),
+        asset_class_identifier: "different-id".to_string(),
+        amount: "".to_string(),
+        recipient: "".to_string(),
+    }), StacksTransactionEvent::FTTransferEvent(chainhook_types::FTTransferEventData {
+        sender: "".to_string(),
+        asset_class_identifier: "asset-id".to_string(),
+        amount: "".to_string(),
+        recipient: "".to_string(),
+    })]], 
+    StacksPredicate::FtEvent(StacksFtEventBasedPredicate {
+        asset_identifier: "asset-id".to_string(),
+        actions: vec!["transfer".to_string()]
+    }),
+    1;
+    "FtEvent predicates match transfer event if matching event is not first in transaction"
+)]
+#[test_case(
     vec![vec![get_test_event_by_type("ft_burn")]], 
     StacksPredicate::FtEvent(StacksFtEventBasedPredicate {
         asset_identifier: "asset-id".to_string(),
@@ -120,6 +139,25 @@ pub mod fixtures;
     }),
     1;
     "NftEvent predicates match transfer event"
+)]
+#[test_case(
+    vec![vec![StacksTransactionEvent::NFTTransferEvent(chainhook_types::NFTTransferEventData {
+        sender: "".to_string(),
+        asset_class_identifier: "different-id".to_string(),
+        hex_asset_identifier: "different-id".to_string(),
+        recipient: "".to_string(),
+    }), StacksTransactionEvent::NFTTransferEvent(chainhook_types::NFTTransferEventData {
+        sender: "".to_string(),
+        asset_class_identifier: "asset-id".to_string(),
+        hex_asset_identifier: "asset-id".to_string(),
+        recipient: "".to_string(),
+    })]], 
+    StacksPredicate::NftEvent(StacksNftEventBasedPredicate {
+        asset_identifier: "asset-id".to_string(),
+        actions: vec!["transfer".to_string()]
+    }),
+    1;
+    "NftEvent predicates match transfer event if matching event is not first in transaction"
 )]
 #[test_case(
     vec![vec![get_test_event_by_type("nft_burn")]], 


### PR DESCRIPTION
### Description

When evaluatin a stacks predicate of type `ft_event` or `nft_event`, we were returning from a loop of all events after the first loop. We should only return early if there is a match, and should continue searching all events if there isn't. This PR implements that fix.

Fixes #469

---

### Checklist

- [x] All tests pass
- [x] Tests added in this PR (if applicable)

