### PR TITLE
fix: use cli feature for `cargo chainhook-install`

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,2 @@
 [alias]
-chainhook-install = "install --path components/chainhook-cli --locked --force"
+chainhook-install = "install --path components/chainhook-cli --locked --force --features cli --features debug --no-default-features"

--- a/components/chainhook-cli/Cargo.toml
+++ b/components/chainhook-cli/Cargo.toml
@@ -59,8 +59,8 @@ serial_test = "2.0.0"
 
 
 [features]
-default = ["cli"]
-cli = ["clap", "clap_generate", "toml", "ctrlc", "release"]
+default = ["cli", "release"]
+cli = ["clap", "clap_generate", "toml", "ctrlc"]
 debug = ["chainhook-sdk/debug"]
 release = ["chainhook-sdk/release"]
 redis_tests = []


### PR DESCRIPTION
Previously, the `cargo chainhook-install` script was installing the sdk version of Chainhook, which logged data in a non-user-friendly way. This changes our features some and updates the install script to fix those logs.