### PR TITLE
fix: validate predicate `start_block` and `end_block`

### DIFF
--- a/components/chainhook-cli/src/scan/bitcoin.rs
+++ b/components/chainhook-cli/src/scan/bitcoin.rs
@@ -111,13 +111,13 @@ pub async fn scan_bitcoin_chainstate_via_rpc_using_predicate(
                     ));
                 }
             };
-            // if not, break out so we can enter streaming mode
+            // if the chain hasn't progressed, break out so we can enter streaming mode
             // and put back the block we weren't able to scan
             if current_block_height > chain_tip {
                 block_heights_to_scan.push_front(current_block_height);
                 break;
             } else {
-                // if so, update our total number of blocks to scan
+                // if the chain has progressed, update our total number of blocks to scan and keep scanning
                 number_of_blocks_to_scan += chain_tip - prev_chain_tip;
             }
         }

--- a/components/chainhook-cli/src/scan/bitcoin.rs
+++ b/components/chainhook-cli/src/scan/bitcoin.rs
@@ -52,12 +52,9 @@ pub async fn scan_bitcoin_chainstate_via_rpc_using_predicate(
             },
         }
     } else {
-        let start_block = match predicate_spec.start_block {
-            Some(start_block) => match &unfinished_scan_data {
-                Some(scan_data) => scan_data.last_evaluated_block_height,
-                None => start_block,
-            },
-            None => 0,
+        let start_block = match &unfinished_scan_data {
+            Some(scan_data) => scan_data.last_evaluated_block_height,
+            None => predicate_spec.start_block.unwrap_or(0),
         };
         let chain_tip = match bitcoin_rpc.get_blockchain_info() {
             Ok(result) => result.blocks,

--- a/components/chainhook-cli/src/scan/common.rs
+++ b/components/chainhook-cli/src/scan/common.rs
@@ -17,8 +17,11 @@ pub fn get_block_heights_to_scan(
                     return Err(format!("Chainhook specification exceeds max number of blocks to scan. Maximum: {}, Attempted: {}", max, specified));
                 }
                 BlockHeightsError::StartLargerThanEnd => {
-                    //todo: improve error
-                    return Err(format!("Unreachable codepath while scanning predicate"));
+                    // this code path should not be reachable
+                    return Err(
+                        "Chainhook specification field `end_block` should be greater than `start_block`."
+                            .into(),
+                    );
                 }
             },
         }

--- a/components/chainhook-cli/src/scan/common.rs
+++ b/components/chainhook-cli/src/scan/common.rs
@@ -1,0 +1,64 @@
+use crate::service::ScanningData;
+use chainhook_sdk::utils::{BlockHeights, BlockHeightsError};
+use std::collections::VecDeque;
+
+pub fn get_block_heights_to_scan(
+    blocks: &Option<Vec<u64>>,
+    start_block: &Option<u64>,
+    end_block: &Option<u64>,
+    chain_tip: &u64,
+    unfinished_scan_data: &Option<ScanningData>,
+) -> Result<Option<VecDeque<u64>>, String> {
+    let block_heights_to_scan = if let Some(ref blocks) = blocks {
+        match BlockHeights::Blocks(blocks.clone()).get_sorted_entries() {
+            Ok(heights) => Some(heights),
+            Err(e) => match e {
+                BlockHeightsError::ExceedsMaxEntries(max, specified) => {
+                    return Err(format!("Chainhook specification exceeds max number of blocks to scan. Maximum: {}, Attempted: {}", max, specified));
+                }
+                BlockHeightsError::StartLargerThanEnd => {
+                    //todo: improve error
+                    return Err(format!("Unreachable codepath while scanning predicate"));
+                }
+            },
+        }
+    } else {
+        let start_block = match &unfinished_scan_data {
+            Some(scan_data) => scan_data.last_evaluated_block_height,
+            None => start_block.unwrap_or(0),
+        };
+
+        let end_block = if let Some(end_block) = end_block {
+            if &start_block > end_block {
+                return Err(
+                    "Chainhook specification field `end_block` should be greater than `start_block`."
+                        .into(),
+                );
+            }
+            end_block
+        } else {
+            chain_tip
+        };
+        if &start_block > end_block {
+            return Ok(None);
+        }
+        let block_heights_to_scan = match BlockHeights::BlockRange(start_block, *end_block)
+            .get_sorted_entries()
+        {
+            Ok(heights) => heights,
+            Err(e) => match e {
+                BlockHeightsError::ExceedsMaxEntries(max, specified) => {
+                    return Err(format!("Chainhook specification exceeds max number of blocks to scan. Maximum: {}, Attempted: {}", max, specified));
+                }
+                BlockHeightsError::StartLargerThanEnd => {
+                    return Err(
+                        "Chainhook specification field `end_block` should be greater than `start_block`."
+                            .into(),
+                    );
+                }
+            },
+        };
+        Some(block_heights_to_scan)
+    };
+    Ok(block_heights_to_scan)
+}

--- a/components/chainhook-cli/src/scan/mod.rs
+++ b/components/chainhook-cli/src/scan/mod.rs
@@ -1,2 +1,6 @@
 pub mod bitcoin;
+pub mod common;
 pub mod stacks;
+
+#[cfg(test)]
+pub mod tests;

--- a/components/chainhook-cli/src/scan/stacks.rs
+++ b/components/chainhook-cli/src/scan/stacks.rs
@@ -225,7 +225,6 @@ pub async fn scan_stacks_chainstate_via_rocksdb_using_predicate(
             let prev_chain_tip = chain_tip;
             // we've scanned up to the chain tip as of the start of this scan
             // so see if the chain has progressed since then
-
             chain_tip = match get_last_unconfirmed_block_height_inserted(stacks_db_conn, ctx) {
                 Some(chain_tip) => chain_tip,
                 None => match get_last_block_height_inserted(stacks_db_conn, ctx) {
@@ -236,13 +235,13 @@ pub async fn scan_stacks_chainstate_via_rocksdb_using_predicate(
                     }
                 },
             };
-            // if not, break out so we can enter streaming mode
+            // if the chain hasn't progressed, break out so we can enter streaming mode
             // and put back the block we weren't able to scan
             if current_block_height > chain_tip {
                 block_heights_to_scan.push_front(current_block_height);
                 break;
             } else {
-                // if so, update our total number of blocks to scan
+                // if the chain has progressed, update our total number of blocks to scan and keep scanning
                 number_of_blocks_to_scan += chain_tip - prev_chain_tip;
             }
         }

--- a/components/chainhook-cli/src/scan/stacks.rs
+++ b/components/chainhook-cli/src/scan/stacks.rs
@@ -184,12 +184,9 @@ pub async fn scan_stacks_chainstate_via_rocksdb_using_predicate(
             },
         }
     } else {
-        let start_block = match predicate_spec.start_block {
-            Some(start_block) => match &unfinished_scan_data {
-                Some(scan_data) => scan_data.last_evaluated_block_height,
-                None => start_block,
-            },
-            None => 0,
+        let start_block = match &unfinished_scan_data {
+            Some(scan_data) => scan_data.last_evaluated_block_height,
+            None => predicate_spec.start_block.unwrap_or(0),
         };
         let chain_tip = match get_last_unconfirmed_block_height_inserted(stacks_db_conn, ctx) {
             Some(chain_tip) => chain_tip,

--- a/components/chainhook-cli/src/scan/tests/mod.rs
+++ b/components/chainhook-cli/src/scan/tests/mod.rs
@@ -89,7 +89,7 @@ fn get_huge_vec() -> Vec<u64> {
 #[test_case(None, Some(1), None, 3, None, Some(VecDeque::from([1,2,3])) => using expect_entries; "chain_tip > start_block, no end_block yields vec from start to chain")]
 #[test_case(None, None, Some(3), 2, None, Some(VecDeque::from([0,1,2,3])) => using expect_entries; "end_block > chain_tip, no start_block yields vec from 0 to end")]
 #[test_case(None, None, Some(2), 3, None, Some(VecDeque::from([0,1,2])) => using expect_entries; "chain_tip > end_block, no yields vec from 0 to end_block")]
-#[test_case(None, Some(0), Some(MAX_BLOCK_HEIGHTS_ENTRIES), 0, None, None => using expect_exceeded_max_entries_error; "limits max number of entries")]
+#[test_case(None, Some(0), Some(MAX_BLOCK_HEIGHTS_ENTRIES + 1), 0, None, None => using expect_exceeded_max_entries_error; "limits max number of entries")]
 #[test_case(None, Some(0), Some(3), 0, Some(ScanningData { number_of_blocks_to_scan: 0, number_of_blocks_evaluated: 0, number_of_times_triggered: 0, last_occurrence: None, last_evaluated_block_height: 2}), Some(VecDeque::from([2,3])) => using expect_entries; "uses previous scan data for start_block if available")]
 #[test_case(Some(vec![0,1,2]), None, None, 0, None, Some(VecDeque::from([0,1,2])) => using expect_entries; "providing blocks returns the same blocks as vec")]
 #[test_case(Some(get_huge_vec()), None, None, 0, None, None => using expect_exceeded_max_entries_error; "providing too many blocks errors")]

--- a/components/chainhook-cli/src/scan/tests/mod.rs
+++ b/components/chainhook-cli/src/scan/tests/mod.rs
@@ -1,0 +1,113 @@
+use std::collections::VecDeque;
+
+use test_case::test_case;
+
+use crate::service::ScanningData;
+
+use super::common::get_block_heights_to_scan;
+
+fn expect_exceeded_max_entries_error(
+    (result, _expected_entries): (Result<Option<VecDeque<u64>>, String>, Option<VecDeque<u64>>),
+) {
+    match result {
+        Ok(_) => panic!("Expected exceeds max entries error."),
+        Err(e) => {
+            if !e.contains("exceeds max number") {
+                panic!("Expected exceeds max entries error. Received error {}", e);
+            }
+        }
+    };
+}
+
+fn expect_start_larger_than_end_error(
+    (result, _expected_entries): (Result<Option<VecDeque<u64>>, String>, Option<VecDeque<u64>>),
+) {
+    match result {
+        Ok(_) => panic!("Expected start larger than end error."),
+        Err(e) => {
+            if !e.contains("field `end_block` should be greater than `start_block`") {
+                panic!("Expected start larger than end error. Received error {}", e);
+            }
+        }
+    };
+}
+fn expect_entries(
+    (result, expected_entries): (Result<Option<VecDeque<u64>>, String>, Option<VecDeque<u64>>),
+) {
+    match result {
+        Ok(actual_entries) => {
+            match actual_entries {
+                None => {
+                    if let Some(expected_entries) = expected_entries {
+                        panic!("No entries found. Expected: {:?}", expected_entries);
+                    }
+                }
+                Some(actual_entries) => {
+                    if let Some(expected_entries) = expected_entries {
+                        assert_eq!(
+                            actual_entries.len(),
+                            expected_entries.len(),
+                            "Number of blocks to scan differs from expected. Actual: {:?}, Expected: {:?}",
+                            actual_entries,
+                            expected_entries
+                        );
+                        for (i, actual_entry) in actual_entries.iter().enumerate() {
+                            let expected_entry = &expected_entries[i];
+                            assert_eq!(actual_entry, expected_entry, "Entry different from expected. Actual: {}, Expected: {}, Index: {}", actual_entry, expected_entry, i);
+                        }
+                    } else {
+                        panic!(
+                            "Found entries when non were expectd. Actual: {:?}",
+                            actual_entries
+                        );
+                    }
+                }
+            }
+        }
+        Err(e) => {
+            panic!("Did not exptect getting block heights to error. Recieved error {e}");
+        }
+    };
+}
+fn get_huge_vec() -> Vec<u64> {
+    let mut vec = vec![];
+    for i in 0..1_000_001 {
+        vec.push(i);
+    }
+    vec
+}
+
+#[test_case(None, Some(1), Some(2), 3, None, Some(VecDeque::from([1,2])) => using expect_entries; "chain_tip > end_block > start_block yields vec from start to end")]
+#[test_case(None, Some(2), Some(1), 3, None, None => using expect_start_larger_than_end_error; "chain_tip > start_block > end_block errors")]
+#[test_case(None, Some(1), Some(3), 2, None, Some(VecDeque::from([1,2,3])) => using expect_entries; "end_block > chain_tip > start_block yields vec from start to end")]
+#[test_case(None, Some(2), Some(3), 1, None, Some(VecDeque::from([2,3])) => using expect_entries; "end_block > start_block > chain_tip yields vec from start to end")]
+#[test_case(None, Some(3), Some(1), 2, None, None => using expect_start_larger_than_end_error; "start_block > chain_tip > end_block errors")]
+#[test_case(None, Some(3), Some(2), 1, None, None => using expect_start_larger_than_end_error; "start_block > end_block > chain_tip errors")]
+#[test_case(None, None, None, 3, None, Some(VecDeque::from([0,1,2,3])) => using expect_entries; "no end_block, no start_block yields 0 to chain_tip")]
+#[test_case(None, Some(3), None, 1, None, None => using expect_entries; "start_block > chain_tip, no end_block yields None")]
+#[test_case(None, Some(1), None, 3, None, Some(VecDeque::from([1,2,3])) => using expect_entries; "chain_tip > start_block, no end_block yields vec from start to chain")]
+#[test_case(None, None, Some(3), 2, None, Some(VecDeque::from([0,1,2,3])) => using expect_entries; "end_block > chain_tip, no start_block yields vec from 0 to end")]
+#[test_case(None, None, Some(2), 3, None, Some(VecDeque::from([0,1,2])) => using expect_entries; "chain_tip > end_block, no yields vec from 0 to end_block")]
+#[test_case(None, Some(0), Some(1_000_000_000), 0, None, None => using expect_exceeded_max_entries_error; "limits max number of entries")]
+#[test_case(None, Some(0), Some(3), 0, Some(ScanningData { number_of_blocks_to_scan: 0, number_of_blocks_evaluated: 0, number_of_times_triggered: 0, last_occurrence: None, last_evaluated_block_height: 2}), Some(VecDeque::from([2,3])) => using expect_entries; "uses previous scan data for start_block if available")]
+#[test_case(Some(vec![0,1,2]), None, None, 0, None, Some(VecDeque::from([0,1,2])) => using expect_entries; "providing blocks returns the same blocks as vec")]
+#[test_case(Some(get_huge_vec()), None, None, 0, None, None => using expect_exceeded_max_entries_error; "providing too many blocks errors")]
+fn test_get_block_heights_to_scan(
+    blocks: Option<Vec<u64>>,
+    start_block: Option<u64>,
+    end_block: Option<u64>,
+    chain_tip: u64,
+    unfinished_scan_data: Option<ScanningData>,
+    expected: Option<VecDeque<u64>>,
+) -> (Result<Option<VecDeque<u64>>, String>, Option<VecDeque<u64>>) {
+    (
+        get_block_heights_to_scan(
+            &blocks,
+            &start_block,
+            &end_block,
+            &chain_tip,
+            &unfinished_scan_data,
+        ),
+        expected,
+    )
+}

--- a/components/chainhook-cli/src/scan/tests/mod.rs
+++ b/components/chainhook-cli/src/scan/tests/mod.rs
@@ -1,5 +1,6 @@
 use std::collections::VecDeque;
 
+use chainhook_sdk::utils::MAX_BLOCK_HEIGHTS_ENTRIES;
 use test_case::test_case;
 
 use crate::service::ScanningData;
@@ -71,7 +72,7 @@ fn expect_entries(
 }
 fn get_huge_vec() -> Vec<u64> {
     let mut vec = vec![];
-    for i in 0..1_000_001 {
+    for i in 0..MAX_BLOCK_HEIGHTS_ENTRIES + 1 {
         vec.push(i);
     }
     vec
@@ -88,7 +89,7 @@ fn get_huge_vec() -> Vec<u64> {
 #[test_case(None, Some(1), None, 3, None, Some(VecDeque::from([1,2,3])) => using expect_entries; "chain_tip > start_block, no end_block yields vec from start to chain")]
 #[test_case(None, None, Some(3), 2, None, Some(VecDeque::from([0,1,2,3])) => using expect_entries; "end_block > chain_tip, no start_block yields vec from 0 to end")]
 #[test_case(None, None, Some(2), 3, None, Some(VecDeque::from([0,1,2])) => using expect_entries; "chain_tip > end_block, no yields vec from 0 to end_block")]
-#[test_case(None, Some(0), Some(1_000_000_000), 0, None, None => using expect_exceeded_max_entries_error; "limits max number of entries")]
+#[test_case(None, Some(0), Some(MAX_BLOCK_HEIGHTS_ENTRIES), 0, None, None => using expect_exceeded_max_entries_error; "limits max number of entries")]
 #[test_case(None, Some(0), Some(3), 0, Some(ScanningData { number_of_blocks_to_scan: 0, number_of_blocks_evaluated: 0, number_of_times_triggered: 0, last_occurrence: None, last_evaluated_block_height: 2}), Some(VecDeque::from([2,3])) => using expect_entries; "uses previous scan data for start_block if available")]
 #[test_case(Some(vec![0,1,2]), None, None, 0, None, Some(VecDeque::from([0,1,2])) => using expect_entries; "providing blocks returns the same blocks as vec")]
 #[test_case(Some(get_huge_vec()), None, None, 0, None, None => using expect_exceeded_max_entries_error; "providing too many blocks errors")]

--- a/components/chainhook-cli/src/service/mod.rs
+++ b/components/chainhook-cli/src/service/mod.rs
@@ -723,9 +723,8 @@ fn set_predicate_streaming_status(
                     number_of_times_triggered,
                     last_evaluated_block_height,
                 ),
-                PredicateStatus::New
-                | PredicateStatus::Interrupted(_)
-                | PredicateStatus::ConfirmedExpiration(_) => {
+                PredicateStatus::New => (None, 0, 0, 0),
+                PredicateStatus::Interrupted(_) | PredicateStatus::ConfirmedExpiration(_) => {
                     warn!(ctx.expect_logger(), "Attempting to set Streaming status when previous status was {:?} for predicate {}", status, predicate_key);
                     return;
                 }

--- a/components/chainhook-cli/src/service/runloops.rs
+++ b/components/chainhook-cli/src/service/runloops.rs
@@ -86,10 +86,21 @@ pub fn start_stacks_scan_runloop(
                     return;
                 }
             };
-            info!(
-                moved_ctx.expect_logger(),
-                "Stacks chainstate scan completed up to block: {}", last_block_scanned.index
-            );
+            match last_block_scanned {
+                Some(last_block_scanned) => {
+                    info!(
+                        moved_ctx.expect_logger(),
+                        "Stacks chainstate scan completed up to block: {}",
+                        last_block_scanned.index
+                    );
+                }
+                None => {
+                    info!(
+                        moved_ctx.expect_logger(),
+                        "Stacks chainstate scan completed. 0 blocks scanned."
+                    );
+                }
+            }
             if !predicate_is_expired {
                 let _ = observer_command_tx.send(ObserverCommand::EnablePredicate(
                     ChainhookSpecification::Stacks(predicate_spec),

--- a/components/chainhook-cli/src/service/tests/mod.rs
+++ b/components/chainhook-cli/src/service/tests/mod.rs
@@ -339,7 +339,7 @@ fn assert_streaming_status(
     }
 }
 
-fn assert_interrupted_status((status, _, _): (PredicateStatus, Option<u64>, Option<u64>)) {
+fn _assert_interrupted_status((status, _, _): (PredicateStatus, Option<u64>, Option<u64>)) {
     match status {
         PredicateStatus::Interrupted(_) => {}
         _ => panic!("expected Interrupted status, found {:?}", status),
@@ -486,7 +486,7 @@ async fn setup_stacks_chainhook_test(
 #[test_case(5, 4, Some(1), Some(7), Some(9), Some(7) => using assert_unconfirmed_expiration_status; "predicate_end_block greater than starting_chain_tip and mining until end_block ends with UnconfirmedExpiration status")]
 #[test_case(1, 3, Some(1), Some(3), Some(4), Some(3) => using assert_unconfirmed_expiration_status; "predicate_end_block greater than starting_chain_tip and mining blocks so that predicate_end_block confirmations < CONFIRMED_SEGMENT_MINIMUM_LENGTH ends with UnconfirmedExpiration status")]
 #[test_case(3, 7, Some(1), Some(4), Some(9), Some(4) => using assert_confirmed_expiration_status; "predicate_end_block greater than starting_chain_tip and mining blocks so that predicate_end_block confirmations >= CONFIRMED_SEGMENT_MINIMUM_LENGTH ends with ConfirmedExpiration status")]
-#[test_case(0, 0, None, None, None, None => using assert_interrupted_status; "ommitting start_block ends with Interrupted status")]
+#[test_case(0, 0, None, None, None, None => using assert_streaming_status; "ommitting start_block is allowed")]
 #[tokio::test]
 #[cfg_attr(not(feature = "redis_tests"), ignore)]
 async fn test_stacks_predicate_status_is_updated(
@@ -641,7 +641,7 @@ async fn setup_bitcoin_chainhook_test(
 #[test_case(10, 1, Some(1), Some(3), Some(3), Some(3) => using assert_confirmed_expiration_status; "predicate_end_block lower than starting_chain_tip with predicate_end_block confirmations >= CONFIRMED_SEGMENT_MINIMUM_LENGTH ends with ConfirmedExpiration status")]
 #[test_case(1, 3, Some(1), Some(3), Some(4), Some(3) => using assert_unconfirmed_expiration_status; "predicate_end_block greater than starting_chain_tip and mining blocks so that predicate_end_block confirmations < CONFIRMED_SEGMENT_MINIMUM_LENGTH ends with UnconfirmedExpiration status")]
 #[test_case(3, 7, Some(1), Some(4), Some(9), Some(4) => using assert_confirmed_expiration_status; "predicate_end_block greater than starting_chain_tip and mining blocks so that predicate_end_block confirmations >= CONFIRMED_SEGMENT_MINIMUM_LENGTH ends with ConfirmedExpiration status")]
-#[test_case(0, 0, None, None, None, None => using assert_interrupted_status; "ommitting start_block ends with Interrupted status")]
+#[test_case(0, 0, None, None, None, None => using assert_streaming_status; "ommitting start_block is allowed")]
 #[tokio::test]
 #[cfg_attr(not(feature = "redis_tests"), ignore)]
 async fn test_bitcoin_predicate_status_is_updated(

--- a/components/chainhook-cli/src/service/tests/mod.rs
+++ b/components/chainhook-cli/src/service/tests/mod.rs
@@ -882,8 +882,8 @@ async fn test_bitcoin_predicate_status_is_updated_with_reorg(
 #[cfg_attr(not(feature = "redis_tests"), ignore)]
 async fn test_deregister_predicate(chain: Chain) {
     let (mut redis_process, working_dir, chainhook_service_port, redis_port, _, _) = match &chain {
-        Chain::Stacks => setup_stacks_chainhook_test(0, None, None).await,
-        Chain::Bitcoin => setup_bitcoin_chainhook_test(0).await,
+        Chain::Stacks => setup_stacks_chainhook_test(3, None, None).await,
+        Chain::Bitcoin => setup_bitcoin_chainhook_test(3).await,
     };
 
     let uuid = &get_random_uuid();

--- a/components/chainhook-sdk/src/chainhooks/types.rs
+++ b/components/chainhook-sdk/src/chainhooks/types.rs
@@ -239,11 +239,29 @@ impl ChainhookFullSpecification {
             Self::Bitcoin(data) => {
                 for (_, spec) in data.networks.iter() {
                     let _ = spec.action.validate()?;
+                    if let Some(end_block) = spec.end_block {
+                        let start_block = spec.start_block.unwrap_or(0);
+                        if start_block > end_block {
+                            return Err(
+                                "Chainhook specification field `end_block` should be greater than `start_block`."
+                                    .into(),
+                            );
+                        }
+                    }
                 }
             }
             Self::Stacks(data) => {
                 for (_, spec) in data.networks.iter() {
                     let _ = spec.action.validate()?;
+                    if let Some(end_block) = spec.end_block {
+                        let start_block = spec.start_block.unwrap_or(0);
+                        if start_block > end_block {
+                            return Err(
+                                "Chainhook specification field `end_block` should be greater than `start_block`."
+                                    .into(),
+                            );
+                        }
+                    }
                 }
             }
         }

--- a/components/chainhook-sdk/src/chainhooks/types.rs
+++ b/components/chainhook-sdk/src/chainhooks/types.rs
@@ -7,6 +7,8 @@ use serde::{de, Deserialize, Deserializer, Serialize};
 
 use schemars::JsonSchema;
 
+use crate::utils::MAX_BLOCK_HEIGHTS_ENTRIES;
+
 #[derive(Deserialize, Debug, Clone)]
 pub struct ChainhookConfig {
     pub stacks_chainhooks: Vec<StacksChainhookSpecification>,
@@ -247,6 +249,9 @@ impl ChainhookFullSpecification {
                                     .into(),
                             );
                         }
+                        if (end_block - start_block) > MAX_BLOCK_HEIGHTS_ENTRIES {
+                            return Err(format!("Chainhook specification exceeds max number of blocks to scan. Maximum: {}, Attempted: {}", MAX_BLOCK_HEIGHTS_ENTRIES, (end_block - start_block)));
+                        }
                     }
                 }
             }
@@ -260,6 +265,9 @@ impl ChainhookFullSpecification {
                                 "Chainhook specification field `end_block` should be greater than `start_block`."
                                     .into(),
                             );
+                        }
+                        if (end_block - start_block) > MAX_BLOCK_HEIGHTS_ENTRIES {
+                            return Err(format!("Chainhook specification exceeds max number of blocks to scan. Maximum: {}, Attempted: {}", MAX_BLOCK_HEIGHTS_ENTRIES, (end_block - start_block)));
                         }
                     }
                 }

--- a/components/chainhook-sdk/src/observer/http.rs
+++ b/components/chainhook-sdk/src/observer/http.rs
@@ -364,14 +364,15 @@ pub async fn handle_bitcoin_wallet_rpc_call(
 ) -> Json<JsonValue> {
     ctx.try_log(|logger| slog::info!(logger, "POST /wallet"));
 
-    use base64::encode;
+    use base64::engine::general_purpose::STANDARD as BASE64;
+    use base64::engine::Engine as _;
     use reqwest::Client;
 
     let bitcoin_rpc_call = bitcoin_rpc_call.into_inner().clone();
 
     let body = rocket::serde::json::serde_json::to_vec(&bitcoin_rpc_call).unwrap_or(vec![]);
 
-    let token = encode(format!(
+    let token = BASE64.encode(format!(
         "{}:{}",
         bitcoin_config.username, bitcoin_config.password
     ));
@@ -401,7 +402,8 @@ pub async fn handle_bitcoin_rpc_call(
 ) -> Json<JsonValue> {
     ctx.try_log(|logger| slog::info!(logger, "POST /"));
 
-    use base64::encode;
+    use base64::engine::general_purpose::STANDARD as BASE64;
+    use base64::engine::Engine as _;
     use reqwest::Client;
 
     let bitcoin_rpc_call = bitcoin_rpc_call.into_inner().clone();
@@ -409,7 +411,7 @@ pub async fn handle_bitcoin_rpc_call(
 
     let body = rocket::serde::json::serde_json::to_vec(&bitcoin_rpc_call).unwrap_or(vec![]);
 
-    let token = encode(format!(
+    let token = BASE64.encode(format!(
         "{}:{}",
         bitcoin_config.username, bitcoin_config.password
     ));

--- a/components/chainhook-sdk/src/utils/mod.rs
+++ b/components/chainhook-sdk/src/utils/mod.rs
@@ -263,7 +263,7 @@ pub enum BlockHeights {
     BlockRange(u64, u64),
     Blocks(Vec<u64>),
 }
-const MAX_ENTRIES: u64 = 1_000_000;
+pub const MAX_BLOCK_HEIGHTS_ENTRIES: u64 = 1_000_000;
 impl BlockHeights {
     pub fn get_sorted_entries(&self) -> Result<VecDeque<u64>, BlockHeightsError> {
         let mut entries = VecDeque::new();
@@ -272,9 +272,9 @@ impl BlockHeights {
                 if start > end {
                     return Err(BlockHeightsError::StartLargerThanEnd);
                 }
-                if (end - start) > MAX_ENTRIES {
+                if (end - start) > MAX_BLOCK_HEIGHTS_ENTRIES {
                     return Err(BlockHeightsError::ExceedsMaxEntries(
-                        MAX_ENTRIES,
+                        MAX_BLOCK_HEIGHTS_ENTRIES,
                         end - start,
                     ));
                 }
@@ -283,9 +283,9 @@ impl BlockHeights {
                 }
             }
             BlockHeights::Blocks(heights) => {
-                if heights.len() as u64 > MAX_ENTRIES {
+                if heights.len() as u64 > MAX_BLOCK_HEIGHTS_ENTRIES {
                     return Err(BlockHeightsError::ExceedsMaxEntries(
-                        MAX_ENTRIES,
+                        MAX_BLOCK_HEIGHTS_ENTRIES,
                         heights.len() as u64,
                     ));
                 }
@@ -319,7 +319,7 @@ fn test_block_heights_range_construct() {
 
 #[test]
 fn test_block_heights_range_limits_entries() {
-    let range = BlockHeights::BlockRange(0, MAX_ENTRIES + 1);
+    let range = BlockHeights::BlockRange(0, MAX_BLOCK_HEIGHTS_ENTRIES + 1);
     match range.get_sorted_entries() {
         Ok(_) => panic!("Expected block heights range to error when exceeding max entries"),
         Err(e) => match e {
@@ -359,7 +359,7 @@ fn test_block_heights_blocks_construct() {
 #[test]
 fn test_block_heights_blocks_limits_entries() {
     let mut too_big = vec![];
-    for i in 0..MAX_ENTRIES + 1 {
+    for i in 0..MAX_BLOCK_HEIGHTS_ENTRIES + 1 {
         too_big.push(i);
     }
     let range = BlockHeights::Blocks(too_big);


### PR DESCRIPTION
### Description

Previously, the scanning threads had some validation for the `start_block` and `end_block` that was incorrect. This PR introduces validation that does the following:
 - We now allow `start_block` to be omitted by the user and we default to 0
 - If there are no blocks in the database, we abort the scan and go to streaming mode rather than erroring (fixes #477)
 - If the user provides an `end_block`, we validate that it is greater than the `start_block`
 - If the `start_block` is greater than chain tip, we abort the scan and go to streaming mode rather than erroring (fixes #464)

This PR also adds some validation to the `BlockHeights` class. Previously, it was possible to overload the `BlockHeights::BlockRange(start_block, end_block)` function to allocate a lot of memory into an empty array. We now have limits on this class. However, due to the above validation, it should not be possible to pass through parameters that reach theses limits (with the current usage of the class) until a chain height is up to `1_000_000`.

---

### Checklist

- [x] All tests pass
- [x] Tests added in this PR (if applicable)

