### PR TITLE
fix: remove unreachable panic; return instead

### DIFF
--- a/components/chainhook-cli/src/service/mod.rs
+++ b/components/chainhook-cli/src/service/mod.rs
@@ -956,11 +956,7 @@ pub fn set_confirmed_expiration_status(
             }
         },
         None => {
-            warn!(
-                ctx.expect_logger(),
-                "found no status for predicate when trying to set confirmed expiration: {}",
-                predicate_key
-            );
+            // None means the predicate was deleted, so we can just ignore this predicate expiring
             return;
         }
     };

--- a/components/chainhook-cli/src/service/mod.rs
+++ b/components/chainhook-cli/src/service/mod.rs
@@ -955,7 +955,14 @@ pub fn set_confirmed_expiration_status(
                 return;
             }
         },
-        None => unreachable!("found no status for predicate: {}", predicate_key),
+        None => {
+            warn!(
+                ctx.expect_logger(),
+                "found no status for predicate when trying to set confirmed expiration: {}",
+                predicate_key
+            );
+            return;
+        }
     };
     update_predicate_status(
         predicate_key,


### PR DESCRIPTION
This error caused chainhook to crash today. This route can happen if a predicate is completed, but we're still waiting on block confirmations for fully expire the predicate, and then the user deletes the predicate.