### PR TITLE
fix: add event index to transaction events

### DIFF
--- a/components/chainhook-cli/src/service/tests/helpers/mock_stacks_node.rs
+++ b/components/chainhook-cli/src/service/tests/helpers/mock_stacks_node.rs
@@ -5,7 +5,7 @@ use chainhook_sdk::indexer::stacks::{NewBlock, NewEvent, NewTransaction};
 use chainhook_sdk::types::{
     FTBurnEventData, FTMintEventData, FTTransferEventData, NFTBurnEventData, NFTMintEventData,
     NFTTransferEventData, STXBurnEventData, STXLockEventData, STXMintEventData,
-    STXTransferEventData, SmartContractEventData, StacksTransactionEvent,
+    STXTransferEventData, SmartContractEventData, StacksTransactionEventPayload,
 };
 
 use super::{branch_and_height_to_prefixed_hash, height_to_prefixed_hash};
@@ -21,69 +21,73 @@ pub fn create_tmp_working_dir() -> Result<(String, String), String> {
         .map_err(|e| format!("failed to create temp working dir: {}", e.to_string()))?;
     Ok((working_dir, tsv_dir))
 }
-fn create_stacks_new_event(tx_index: u64, index: u32, event: StacksTransactionEvent) -> NewEvent {
+fn create_stacks_new_event(
+    tx_index: u64,
+    index: u32,
+    event: StacksTransactionEventPayload,
+) -> NewEvent {
     let mut event_type = String::new();
-    let stx_transfer_event = if let StacksTransactionEvent::STXTransferEvent(data) = &event {
+    let stx_transfer_event = if let StacksTransactionEventPayload::STXTransferEvent(data) = &event {
         event_type = format!("stx_transfer");
         Some(serde_json::to_value(data).unwrap())
     } else {
         None
     };
-    let stx_mint_event = if let StacksTransactionEvent::STXMintEvent(data) = &event {
+    let stx_mint_event = if let StacksTransactionEventPayload::STXMintEvent(data) = &event {
         event_type = format!("stx_mint");
         Some(serde_json::to_value(data).unwrap())
     } else {
         None
     };
-    let stx_burn_event = if let StacksTransactionEvent::STXBurnEvent(data) = &event {
+    let stx_burn_event = if let StacksTransactionEventPayload::STXBurnEvent(data) = &event {
         event_type = format!("stx_burn");
         Some(serde_json::to_value(data).unwrap())
     } else {
         None
     };
-    let stx_lock_event = if let StacksTransactionEvent::STXLockEvent(data) = &event {
+    let stx_lock_event = if let StacksTransactionEventPayload::STXLockEvent(data) = &event {
         event_type = format!("stx_lock");
         Some(serde_json::to_value(data).unwrap())
     } else {
         None
     };
-    let nft_transfer_event = if let StacksTransactionEvent::NFTTransferEvent(data) = &event {
+    let nft_transfer_event = if let StacksTransactionEventPayload::NFTTransferEvent(data) = &event {
         event_type = format!("nft_transfer");
         Some(serde_json::to_value(data).unwrap())
     } else {
         None
     };
-    let nft_mint_event = if let StacksTransactionEvent::NFTMintEvent(data) = &event {
+    let nft_mint_event = if let StacksTransactionEventPayload::NFTMintEvent(data) = &event {
         event_type = format!("nft_mint");
         Some(serde_json::to_value(data).unwrap())
     } else {
         None
     };
-    let nft_burn_event = if let StacksTransactionEvent::NFTBurnEvent(data) = &event {
+    let nft_burn_event = if let StacksTransactionEventPayload::NFTBurnEvent(data) = &event {
         event_type = format!("nft_burn");
         Some(serde_json::to_value(data).unwrap())
     } else {
         None
     };
-    let ft_transfer_event = if let StacksTransactionEvent::FTTransferEvent(data) = &event {
+    let ft_transfer_event = if let StacksTransactionEventPayload::FTTransferEvent(data) = &event {
         event_type = format!("ft_transfer");
         Some(serde_json::to_value(data).unwrap())
     } else {
         None
     };
-    let ft_mint_event = if let StacksTransactionEvent::FTMintEvent(data) = &event {
+    let ft_mint_event = if let StacksTransactionEventPayload::FTMintEvent(data) = &event {
         event_type = format!("ft_mint");
         Some(serde_json::to_value(data).unwrap())
     } else {
         None
     };
-    let ft_burn_event = if let StacksTransactionEvent::FTBurnEvent(data) = &event {
+    let ft_burn_event = if let StacksTransactionEventPayload::FTBurnEvent(data) = &event {
         event_type = format!("ft_burn");
         Some(serde_json::to_value(data).unwrap())
     } else {
         None
     };
-    let contract_event = if let StacksTransactionEvent::SmartContractEvent(data) = &event {
+    let contract_event = if let StacksTransactionEventPayload::SmartContractEvent(data) = &event {
         event_type = format!("smart_contract_print_event");
         Some(serde_json::to_value(data).unwrap())
     } else {
@@ -136,7 +140,7 @@ pub fn create_stacks_new_block(height: u64, burn_block_height: u64) -> NewBlock 
     events.push(create_stacks_new_event(
         0,
         events.len() as u32,
-        StacksTransactionEvent::STXTransferEvent(STXTransferEventData {
+        StacksTransactionEventPayload::STXTransferEvent(STXTransferEventData {
             sender: format!(""),
             recipient: format!(""),
             amount: format!("1"),
@@ -145,7 +149,7 @@ pub fn create_stacks_new_block(height: u64, burn_block_height: u64) -> NewBlock 
     events.push(create_stacks_new_event(
         0,
         events.len() as u32,
-        StacksTransactionEvent::STXMintEvent(STXMintEventData {
+        StacksTransactionEventPayload::STXMintEvent(STXMintEventData {
             recipient: format!(""),
             amount: format!("1"),
         }),
@@ -153,7 +157,7 @@ pub fn create_stacks_new_block(height: u64, burn_block_height: u64) -> NewBlock 
     events.push(create_stacks_new_event(
         0,
         events.len() as u32,
-        StacksTransactionEvent::STXBurnEvent(STXBurnEventData {
+        StacksTransactionEventPayload::STXBurnEvent(STXBurnEventData {
             sender: format!(""),
             amount: format!("1"),
         }),
@@ -161,7 +165,7 @@ pub fn create_stacks_new_block(height: u64, burn_block_height: u64) -> NewBlock 
     events.push(create_stacks_new_event(
         0,
         events.len() as u32,
-        StacksTransactionEvent::STXLockEvent(STXLockEventData {
+        StacksTransactionEventPayload::STXLockEvent(STXLockEventData {
             locked_amount: format!("1"),
             unlock_height: format!(""),
             locked_address: format!(""),
@@ -170,7 +174,7 @@ pub fn create_stacks_new_block(height: u64, burn_block_height: u64) -> NewBlock 
     events.push(create_stacks_new_event(
         0,
         events.len() as u32,
-        StacksTransactionEvent::NFTTransferEvent(NFTTransferEventData {
+        StacksTransactionEventPayload::NFTTransferEvent(NFTTransferEventData {
             asset_class_identifier: format!(""),
             hex_asset_identifier: format!(""),
             sender: format!(""),
@@ -180,7 +184,7 @@ pub fn create_stacks_new_block(height: u64, burn_block_height: u64) -> NewBlock 
     events.push(create_stacks_new_event(
         0,
         events.len() as u32,
-        StacksTransactionEvent::NFTMintEvent(NFTMintEventData {
+        StacksTransactionEventPayload::NFTMintEvent(NFTMintEventData {
             asset_class_identifier: format!(""),
             hex_asset_identifier: format!(""),
             recipient: format!(""),
@@ -189,7 +193,7 @@ pub fn create_stacks_new_block(height: u64, burn_block_height: u64) -> NewBlock 
     events.push(create_stacks_new_event(
         0,
         events.len() as u32,
-        StacksTransactionEvent::NFTBurnEvent(NFTBurnEventData {
+        StacksTransactionEventPayload::NFTBurnEvent(NFTBurnEventData {
             asset_class_identifier: format!(""),
             hex_asset_identifier: format!(""),
             sender: format!(""),
@@ -198,7 +202,7 @@ pub fn create_stacks_new_block(height: u64, burn_block_height: u64) -> NewBlock 
     events.push(create_stacks_new_event(
         0,
         events.len() as u32,
-        StacksTransactionEvent::FTTransferEvent(FTTransferEventData {
+        StacksTransactionEventPayload::FTTransferEvent(FTTransferEventData {
             asset_class_identifier: format!(""),
             sender: format!(""),
             recipient: format!(""),
@@ -208,7 +212,7 @@ pub fn create_stacks_new_block(height: u64, burn_block_height: u64) -> NewBlock 
     events.push(create_stacks_new_event(
         0,
         events.len() as u32,
-        StacksTransactionEvent::FTMintEvent(FTMintEventData {
+        StacksTransactionEventPayload::FTMintEvent(FTMintEventData {
             asset_class_identifier: format!(""),
             recipient: format!(""),
             amount: format!("1"),
@@ -217,7 +221,7 @@ pub fn create_stacks_new_block(height: u64, burn_block_height: u64) -> NewBlock 
     events.push(create_stacks_new_event(
         0,
         events.len() as u32,
-        StacksTransactionEvent::FTBurnEvent(FTBurnEventData {
+        StacksTransactionEventPayload::FTBurnEvent(FTBurnEventData {
             asset_class_identifier: format!(""),
             sender: format!(""),
             amount: format!("1"),
@@ -226,7 +230,7 @@ pub fn create_stacks_new_block(height: u64, burn_block_height: u64) -> NewBlock 
     events.push(create_stacks_new_event(
         0,
         events.len() as u32,
-        StacksTransactionEvent::SmartContractEvent(SmartContractEventData {
+        StacksTransactionEventPayload::SmartContractEvent(SmartContractEventData {
             contract_identifier: format!(""),
             topic: format!("print"),
             hex_value: format!(""),

--- a/components/chainhook-sdk/src/chainhooks/stacks/mod.rs
+++ b/components/chainhook-sdk/src/chainhooks/stacks/mod.rs
@@ -377,7 +377,7 @@ pub fn evaluate_stacks_predicate_on_transaction<'a>(
 
             for event in transaction.metadata.receipt.events.iter() {
                 match (
-                    event.event_payload,
+                    &event.event_payload,
                     expecting_mint,
                     expecting_transfer,
                     expecting_burn,
@@ -418,7 +418,7 @@ pub fn evaluate_stacks_predicate_on_transaction<'a>(
 
             for event in transaction.metadata.receipt.events.iter() {
                 match (
-                    event.event_payload,
+                    &event.event_payload,
                     expecting_mint,
                     expecting_transfer,
                     expecting_burn,

--- a/components/chainhook-sdk/src/chainhooks/tests/fixtures/mod.rs
+++ b/components/chainhook-sdk/src/chainhooks/tests/fixtures/mod.rs
@@ -72,24 +72,24 @@ pub fn get_expected_occurrence() -> String {
     std::include_str!("stacks/testnet/occurrence.json").to_owned()
 }
 
-pub fn get_all_event_types() -> Vec<StacksTransactionEventPayload> {
+pub fn get_all_event_payload_types() -> Vec<StacksTransactionEventPayload> {
     vec![
-        get_test_event_by_type("stx_transfer"),
-        get_test_event_by_type("stx_mint"),
-        get_test_event_by_type("stx_lock"),
-        get_test_event_by_type("stx_burn"),
-        get_test_event_by_type("nft_transfer"),
-        get_test_event_by_type("nft_mint"),
-        get_test_event_by_type("nft_burn"),
-        get_test_event_by_type("ft_transfer"),
-        get_test_event_by_type("ft_mint"),
-        get_test_event_by_type("ft_burn"),
-        get_test_event_by_type("smart_contract_print_event"),
-        get_test_event_by_type("smart_contract_print_event_empty"),
-        get_test_event_by_type("smart_contract_not_print_event"),
+        get_test_event_payload_by_type("stx_transfer"),
+        get_test_event_payload_by_type("stx_mint"),
+        get_test_event_payload_by_type("stx_lock"),
+        get_test_event_payload_by_type("stx_burn"),
+        get_test_event_payload_by_type("nft_transfer"),
+        get_test_event_payload_by_type("nft_mint"),
+        get_test_event_payload_by_type("nft_burn"),
+        get_test_event_payload_by_type("ft_transfer"),
+        get_test_event_payload_by_type("ft_mint"),
+        get_test_event_payload_by_type("ft_burn"),
+        get_test_event_payload_by_type("smart_contract_print_event"),
+        get_test_event_payload_by_type("smart_contract_print_event_empty"),
+        get_test_event_payload_by_type("smart_contract_not_print_event"),
     ]
 }
-pub fn get_test_event_by_type(event_type: &str) -> StacksTransactionEventPayload {
+pub fn get_test_event_payload_by_type(event_type: &str) -> StacksTransactionEventPayload {
     match event_type {
         "stx_transfer" => StacksTransactionEventPayload::STXTransferEvent(STXTransferEventData {
             sender: "".to_string(),

--- a/components/chainhook-sdk/src/chainhooks/tests/fixtures/mod.rs
+++ b/components/chainhook-sdk/src/chainhooks/tests/fixtures/mod.rs
@@ -1,9 +1,10 @@
-use chainhook_types::StacksBlockData;
 use chainhook_types::{
     FTBurnEventData, FTMintEventData, FTTransferEventData, NFTBurnEventData, NFTMintEventData,
     NFTTransferEventData, STXBurnEventData, STXLockEventData, STXMintEventData,
-    STXTransferEventData, SmartContractEventData, StacksTransactionData, StacksTransactionEvent,
+    STXTransferEventData, SmartContractEventData, StacksTransactionData,
+    StacksTransactionEventPayload,
 };
+use chainhook_types::{StacksBlockData, StacksTransactionEvent};
 use std::collections::HashMap;
 
 lazy_static! {
@@ -71,7 +72,7 @@ pub fn get_expected_occurrence() -> String {
     std::include_str!("stacks/testnet/occurrence.json").to_owned()
 }
 
-pub fn get_all_event_types() -> Vec<StacksTransactionEvent> {
+pub fn get_all_event_types() -> Vec<StacksTransactionEventPayload> {
     vec![
         get_test_event_by_type("stx_transfer"),
         get_test_event_by_type("stx_mint"),
@@ -88,54 +89,54 @@ pub fn get_all_event_types() -> Vec<StacksTransactionEvent> {
         get_test_event_by_type("smart_contract_not_print_event"),
     ]
 }
-pub fn get_test_event_by_type(event_type: &str) -> StacksTransactionEvent {
+pub fn get_test_event_by_type(event_type: &str) -> StacksTransactionEventPayload {
     match event_type {
-        "stx_transfer" => StacksTransactionEvent::STXTransferEvent(STXTransferEventData {
+        "stx_transfer" => StacksTransactionEventPayload::STXTransferEvent(STXTransferEventData {
             sender: "".to_string(),
             recipient: "".to_string(),
             amount: "".to_string(),
         }),
-        "stx_mint" => StacksTransactionEvent::STXMintEvent(STXMintEventData {
+        "stx_mint" => StacksTransactionEventPayload::STXMintEvent(STXMintEventData {
             recipient: "".to_string(),
             amount: "".to_string(),
         }),
-        "stx_lock" => StacksTransactionEvent::STXLockEvent(STXLockEventData {
+        "stx_lock" => StacksTransactionEventPayload::STXLockEvent(STXLockEventData {
             locked_amount: "".to_string(),
             unlock_height: "".to_string(),
             locked_address: "".to_string(),
         }),
-        "stx_burn" => StacksTransactionEvent::STXBurnEvent(STXBurnEventData {
+        "stx_burn" => StacksTransactionEventPayload::STXBurnEvent(STXBurnEventData {
             sender: "".to_string(),
             amount: "".to_string(),
         }),
-        "nft_transfer" => StacksTransactionEvent::NFTTransferEvent(NFTTransferEventData {
+        "nft_transfer" => StacksTransactionEventPayload::NFTTransferEvent(NFTTransferEventData {
             sender: "".to_string(),
             asset_class_identifier: "asset-id".to_string(),
             hex_asset_identifier: "asset-id".to_string(),
             recipient: "".to_string(),
         }),
-        "nft_mint" => StacksTransactionEvent::NFTMintEvent(NFTMintEventData {
+        "nft_mint" => StacksTransactionEventPayload::NFTMintEvent(NFTMintEventData {
             asset_class_identifier: "asset-id".to_string(),
             hex_asset_identifier: "asset-id".to_string(),
             recipient: "".to_string(),
         }),
-        "nft_burn" => StacksTransactionEvent::NFTBurnEvent(NFTBurnEventData {
+        "nft_burn" => StacksTransactionEventPayload::NFTBurnEvent(NFTBurnEventData {
             asset_class_identifier: "asset-id".to_string(),
             hex_asset_identifier: "asset-id".to_string(),
             sender: "".to_string(),
         }),
-        "ft_transfer" => StacksTransactionEvent::FTTransferEvent(FTTransferEventData {
+        "ft_transfer" => StacksTransactionEventPayload::FTTransferEvent(FTTransferEventData {
             sender: "".to_string(),
             asset_class_identifier: "asset-id".to_string(),
             amount: "".to_string(),
             recipient: "".to_string(),
         }),
-        "ft_mint" => StacksTransactionEvent::FTMintEvent(FTMintEventData {
+        "ft_mint" => StacksTransactionEventPayload::FTMintEvent(FTMintEventData {
             asset_class_identifier: "asset-id".to_string(),
             recipient: "".to_string(),
             amount: "".to_string(),
         }),
-        "ft_burn" => StacksTransactionEvent::FTBurnEvent(FTBurnEventData {
+        "ft_burn" => StacksTransactionEventPayload::FTBurnEvent(FTBurnEventData {
             asset_class_identifier: "asset-id".to_string(),
             sender: "".to_string(),
             amount: "".to_string(),
@@ -145,7 +146,7 @@ pub fn get_test_event_by_type(event_type: &str) -> StacksTransactionEvent {
         "data_map_update" => todo!(),
         "data_map_delete" => todo!(),
         "smart_contract_print_event" => {
-            StacksTransactionEvent::SmartContractEvent(SmartContractEventData {
+            StacksTransactionEventPayload::SmartContractEvent(SmartContractEventData {
                 topic: "print".to_string(),
                 contract_identifier: "ST3AXH4EBHD63FCFPTZ8GR29TNTVWDYPGY0KDY5E5.loan-data"
                     .to_string(),
@@ -153,14 +154,14 @@ pub fn get_test_event_by_type(event_type: &str) -> StacksTransactionEvent {
             })
         }
         "smart_contract_print_event_empty" => {
-            StacksTransactionEvent::SmartContractEvent(SmartContractEventData {
+            StacksTransactionEventPayload::SmartContractEvent(SmartContractEventData {
                 topic: "print".to_string(),
                 contract_identifier: "some-id".to_string(),
                 hex_value: EMPTY_EVENT_HEX.to_string(),
             })
         }
         "smart_contract_not_print_event" => {
-            StacksTransactionEvent::SmartContractEvent(SmartContractEventData {
+            StacksTransactionEventPayload::SmartContractEvent(SmartContractEventData {
                 topic: "not-print".to_string(),
                 contract_identifier: "ST3AXH4EBHD63FCFPTZ8GR29TNTVWDYPGY0KDY5E5.loan-data"
                     .to_string(),

--- a/components/chainhook-sdk/src/chainhooks/tests/fixtures/stacks/testnet/occurrence.json
+++ b/components/chainhook-sdk/src/chainhooks/tests/fixtures/stacks/testnet/occurrence.json
@@ -59,6 +59,9 @@
                     "recipient": "",
                     "sender": ""
                   },
+                  "position": {
+                    "index": 0
+                  },
                   "type": "STXTransferEvent"
                 }
               ],
@@ -136,6 +139,9 @@
                   "data": {
                     "amount": "",
                     "recipient": ""
+                  },
+                  "position": {
+                    "index": 0
                   },
                   "type": "STXMintEvent"
                 }
@@ -216,6 +222,9 @@
                     "locked_amount": "",
                     "unlock_height": ""
                   },
+                  "position": {
+                    "index": 0
+                  },
                   "type": "STXLockEvent"
                 }
               ],
@@ -293,6 +302,9 @@
                   "data": {
                     "amount": "",
                     "sender": ""
+                  },
+                  "position": {
+                    "index": 0
                   },
                   "type": "STXBurnEvent"
                 }
@@ -374,6 +386,9 @@
                     "recipient": "",
                     "sender": ""
                   },
+                  "position": {
+                    "index": 0
+                  },
                   "type": "NFTTransferEvent"
                 }
               ],
@@ -453,6 +468,9 @@
                     "asset_identifier": "asset-id",
                     "recipient": ""
                   },
+                  "position": {
+                    "index": 0
+                  },
                   "type": "NFTMintEvent"
                 }
               ],
@@ -531,6 +549,9 @@
                     "asset_class_identifier": "asset-id",
                     "asset_identifier": "asset-id",
                     "sender": ""
+                  },
+                  "position": {
+                    "index": 0
                   },
                   "type": "NFTBurnEvent"
                 }
@@ -612,6 +633,9 @@
                     "recipient": "",
                     "sender": ""
                   },
+                  "position": {
+                    "index": 0
+                  },
                   "type": "FTTransferEvent"
                 }
               ],
@@ -690,6 +714,9 @@
                     "amount": "",
                     "asset_identifier": "asset-id",
                     "recipient": ""
+                  },
+                  "position": {
+                    "index": 0
                   },
                   "type": "FTMintEvent"
                 }
@@ -770,6 +797,9 @@
                     "asset_identifier": "asset-id",
                     "sender": ""
                   },
+                  "position": {
+                    "index": 0
+                  },
                   "type": "FTBurnEvent"
                 }
               ],
@@ -848,6 +878,9 @@
                     "contract_identifier": "ST3AXH4EBHD63FCFPTZ8GR29TNTVWDYPGY0KDY5E5.loan-data",
                     "topic": "print",
                     "value": "abcsome-valueabc"
+                  },
+                  "position": {
+                    "index": 0
                   },
                   "type": "SmartContractEvent"
                 }
@@ -928,6 +961,9 @@
                     "topic": "print",
                     "value": ""
                   },
+                  "position": {
+                    "index": 0
+                  },
                   "type": "SmartContractEvent"
                 }
               ],
@@ -1006,6 +1042,9 @@
                     "contract_identifier": "ST3AXH4EBHD63FCFPTZ8GR29TNTVWDYPGY0KDY5E5.loan-data",
                     "topic": "not-print",
                     "value": "abcsome-valueabc"
+                  },
+                  "position": {
+                    "index": 0
                   },
                   "type": "SmartContractEvent"
                 }

--- a/components/chainhook-sdk/src/chainhooks/tests/mod.rs
+++ b/components/chainhook-sdk/src/chainhooks/tests/mod.rs
@@ -22,8 +22,10 @@ use crate::{
     },
     utils::AbstractStacksBlock,
 };
-use chainhook_types::{StacksBlockUpdate, StacksChainEvent, StacksChainUpdatedWithBlocksData};
-use chainhook_types::{StacksNetwork, StacksTransactionData, StacksTransactionEvent};
+use chainhook_types::{
+    StacksBlockUpdate, StacksChainEvent, StacksChainUpdatedWithBlocksData, StacksNetwork,
+    StacksTransactionData, StacksTransactionEvent, StacksTransactionEventPayload,
+};
 use serde_json::Value as JsonValue;
 use test_case::test_case;
 
@@ -31,7 +33,7 @@ pub mod fixtures;
 
 // FtEvent predicate tests
 #[test_case(
-    vec![vec![get_test_event_by_type("ft_mint")]], 
+    vec![vec![get_test_event_by_type("ft_mint")]],
     StacksPredicate::FtEvent(StacksFtEventBasedPredicate {
         asset_identifier: "asset-id".to_string(),
         actions: vec!["mint".to_string()]
@@ -40,7 +42,7 @@ pub mod fixtures;
     "FtEvent predicates match mint event"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("ft_transfer")]], 
+    vec![vec![get_test_event_by_type("ft_transfer")]],
     StacksPredicate::FtEvent(StacksFtEventBasedPredicate {
         asset_identifier: "asset-id".to_string(),
         actions: vec!["transfer".to_string()]
@@ -49,17 +51,17 @@ pub mod fixtures;
     "FtEvent predicates match transfer event"
 )]
 #[test_case(
-    vec![vec![StacksTransactionEvent::FTTransferEvent(chainhook_types::FTTransferEventData {
+    vec![vec![StacksTransactionEventPayload::FTTransferEvent(chainhook_types::FTTransferEventData {
         sender: "".to_string(),
         asset_class_identifier: "different-id".to_string(),
         amount: "".to_string(),
         recipient: "".to_string(),
-    }), StacksTransactionEvent::FTTransferEvent(chainhook_types::FTTransferEventData {
+    }), StacksTransactionEventPayload::FTTransferEvent(chainhook_types::FTTransferEventData {
         sender: "".to_string(),
         asset_class_identifier: "asset-id".to_string(),
         amount: "".to_string(),
         recipient: "".to_string(),
-    })]], 
+    })]],
     StacksPredicate::FtEvent(StacksFtEventBasedPredicate {
         asset_identifier: "asset-id".to_string(),
         actions: vec!["transfer".to_string()]
@@ -68,7 +70,7 @@ pub mod fixtures;
     "FtEvent predicates match transfer event if matching event is not first in transaction"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("ft_burn")]], 
+    vec![vec![get_test_event_by_type("ft_burn")]],
     StacksPredicate::FtEvent(StacksFtEventBasedPredicate {
         asset_identifier: "asset-id".to_string(),
         actions: vec!["burn".to_string()]
@@ -77,7 +79,7 @@ pub mod fixtures;
     "FtEvent predicates match burn event"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("ft_mint")]], 
+    vec![vec![get_test_event_by_type("ft_mint")]],
     StacksPredicate::FtEvent(StacksFtEventBasedPredicate {
         asset_identifier: "wrong-id".to_string(),
         actions: vec!["mint".to_string()]
@@ -86,7 +88,7 @@ pub mod fixtures;
     "FtEvent predicates reject no-match asset id for mint event"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("ft_transfer")]], 
+    vec![vec![get_test_event_by_type("ft_transfer")]],
     StacksPredicate::FtEvent(StacksFtEventBasedPredicate {
         asset_identifier: "wrong-id".to_string(),
         actions: vec!["transfer".to_string()]
@@ -95,7 +97,7 @@ pub mod fixtures;
     "FtEvent predicates reject no-match asset id for transfer event"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("ft_burn")]], 
+    vec![vec![get_test_event_by_type("ft_burn")]],
     StacksPredicate::FtEvent(StacksFtEventBasedPredicate {
         asset_identifier: "wrong-id".to_string(),
         actions: vec!["burn".to_string()]
@@ -104,7 +106,7 @@ pub mod fixtures;
     "FtEvent predicates reject no-match asset id for burn event"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("ft_mint")],vec![get_test_event_by_type("ft_transfer")],vec![get_test_event_by_type("ft_burn")]], 
+    vec![vec![get_test_event_by_type("ft_mint")],vec![get_test_event_by_type("ft_transfer")],vec![get_test_event_by_type("ft_burn")]],
     StacksPredicate::FtEvent(StacksFtEventBasedPredicate {
         asset_identifier: "asset-id".to_string(),
         actions: vec!["mint".to_string(),"transfer".to_string(), "burn".to_string()]
@@ -113,7 +115,7 @@ pub mod fixtures;
     "FtEvent predicates match multiple events"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("ft_transfer")],vec![get_test_event_by_type("ft_burn")]], 
+    vec![vec![get_test_event_by_type("ft_transfer")],vec![get_test_event_by_type("ft_burn")]],
     StacksPredicate::FtEvent(StacksFtEventBasedPredicate {
         asset_identifier: "asset-id".to_string(),
         actions: vec!["mint".to_string()]
@@ -123,7 +125,7 @@ pub mod fixtures;
 )]
 // NftEvent predicate tests
 #[test_case(
-    vec![vec![get_test_event_by_type("nft_mint")]], 
+    vec![vec![get_test_event_by_type("nft_mint")]],
     StacksPredicate::NftEvent(StacksNftEventBasedPredicate {
         asset_identifier: "asset-id".to_string(),
         actions: vec!["mint".to_string()]
@@ -132,7 +134,7 @@ pub mod fixtures;
     "NftEvent predicates match mint event"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("nft_transfer")]], 
+    vec![vec![get_test_event_by_type("nft_transfer")]],
     StacksPredicate::NftEvent(StacksNftEventBasedPredicate {
         asset_identifier: "asset-id".to_string(),
         actions: vec!["transfer".to_string()]
@@ -141,17 +143,17 @@ pub mod fixtures;
     "NftEvent predicates match transfer event"
 )]
 #[test_case(
-    vec![vec![StacksTransactionEvent::NFTTransferEvent(chainhook_types::NFTTransferEventData {
+    vec![vec![StacksTransactionEventPayload::NFTTransferEvent(chainhook_types::NFTTransferEventData {
         sender: "".to_string(),
         asset_class_identifier: "different-id".to_string(),
         hex_asset_identifier: "different-id".to_string(),
         recipient: "".to_string(),
-    }), StacksTransactionEvent::NFTTransferEvent(chainhook_types::NFTTransferEventData {
+    }), StacksTransactionEventPayload::NFTTransferEvent(chainhook_types::NFTTransferEventData {
         sender: "".to_string(),
         asset_class_identifier: "asset-id".to_string(),
         hex_asset_identifier: "asset-id".to_string(),
         recipient: "".to_string(),
-    })]], 
+    })]],
     StacksPredicate::NftEvent(StacksNftEventBasedPredicate {
         asset_identifier: "asset-id".to_string(),
         actions: vec!["transfer".to_string()]
@@ -160,7 +162,7 @@ pub mod fixtures;
     "NftEvent predicates match transfer event if matching event is not first in transaction"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("nft_burn")]], 
+    vec![vec![get_test_event_by_type("nft_burn")]],
     StacksPredicate::NftEvent(StacksNftEventBasedPredicate {
         asset_identifier: "asset-id".to_string(),
         actions: vec!["burn".to_string()]
@@ -169,7 +171,7 @@ pub mod fixtures;
     "NftEvent predicates match burn event"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("nft_mint")]], 
+    vec![vec![get_test_event_by_type("nft_mint")]],
     StacksPredicate::NftEvent(StacksNftEventBasedPredicate {
         asset_identifier: "wrong-id".to_string(),
         actions: vec!["mint".to_string()]
@@ -178,7 +180,7 @@ pub mod fixtures;
     "NftEvent predicates reject no-match asset id for mint event"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("nft_transfer")]], 
+    vec![vec![get_test_event_by_type("nft_transfer")]],
     StacksPredicate::NftEvent(StacksNftEventBasedPredicate {
         asset_identifier: "wrong-id".to_string(),
         actions: vec!["transfer".to_string()]
@@ -187,7 +189,7 @@ pub mod fixtures;
     "NftEvent predicates reject no-match asset id for transfer event"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("nft_burn")]], 
+    vec![vec![get_test_event_by_type("nft_burn")]],
     StacksPredicate::NftEvent(StacksNftEventBasedPredicate {
         asset_identifier: "wrong-id".to_string(),
         actions: vec!["burn".to_string()]
@@ -196,7 +198,7 @@ pub mod fixtures;
     "NftEvent predicates reject no-match asset id for burn event"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("nft_mint")],vec![get_test_event_by_type("nft_transfer")],vec![get_test_event_by_type("nft_burn")]], 
+    vec![vec![get_test_event_by_type("nft_mint")],vec![get_test_event_by_type("nft_transfer")],vec![get_test_event_by_type("nft_burn")]],
     StacksPredicate::NftEvent(StacksNftEventBasedPredicate {
         asset_identifier: "asset-id".to_string(),
         actions: vec!["mint".to_string(),"transfer".to_string(), "burn".to_string()]
@@ -205,7 +207,7 @@ pub mod fixtures;
     "NftEvent predicates match multiple events"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("nft_transfer")],vec![get_test_event_by_type("nft_burn")]], 
+    vec![vec![get_test_event_by_type("nft_transfer")],vec![get_test_event_by_type("nft_burn")]],
     StacksPredicate::NftEvent(StacksNftEventBasedPredicate {
         asset_identifier: "asset-id".to_string(),
         actions: vec!["mint".to_string()]
@@ -215,7 +217,7 @@ pub mod fixtures;
 )]
 // StxEvent predicate tests
 #[test_case(
-    vec![vec![get_test_event_by_type("stx_mint")]], 
+    vec![vec![get_test_event_by_type("stx_mint")]],
     StacksPredicate::StxEvent(StacksStxEventBasedPredicate {
         actions: vec!["mint".to_string()]
     }),
@@ -223,7 +225,7 @@ pub mod fixtures;
     "StxEvent predicates match mint event"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("stx_transfer")]], 
+    vec![vec![get_test_event_by_type("stx_transfer")]],
     StacksPredicate::StxEvent(StacksStxEventBasedPredicate {
         actions: vec!["transfer".to_string()]
     }),
@@ -231,7 +233,7 @@ pub mod fixtures;
     "StxEvent predicates match transfer event"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("stx_lock")]], 
+    vec![vec![get_test_event_by_type("stx_lock")]],
     StacksPredicate::StxEvent(StacksStxEventBasedPredicate {
         actions: vec!["lock".to_string()]
     }),
@@ -239,7 +241,7 @@ pub mod fixtures;
     "StxEvent predicates match lock event"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("stx_burn")]], 
+    vec![vec![get_test_event_by_type("stx_burn")]],
     StacksPredicate::StxEvent(StacksStxEventBasedPredicate {
         actions: vec!["burn".to_string()]
     }),
@@ -247,7 +249,7 @@ pub mod fixtures;
     "StxEvent predicates match burn event"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("stx_mint")],vec![get_test_event_by_type("stx_transfer")],vec![get_test_event_by_type("stx_lock")]], 
+    vec![vec![get_test_event_by_type("stx_mint")],vec![get_test_event_by_type("stx_transfer")],vec![get_test_event_by_type("stx_lock")]],
     StacksPredicate::StxEvent(StacksStxEventBasedPredicate {
         actions: vec!["mint".to_string(), "transfer".to_string(), "lock".to_string()]
     }),
@@ -255,7 +257,7 @@ pub mod fixtures;
     "StxEvent predicates match multiple events"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("stx_transfer")],vec![get_test_event_by_type("stx_lock")]], 
+    vec![vec![get_test_event_by_type("stx_transfer")],vec![get_test_event_by_type("stx_lock")]],
     StacksPredicate::StxEvent(StacksStxEventBasedPredicate {
         actions: vec!["mint".to_string()]
     }),
@@ -264,7 +266,7 @@ pub mod fixtures;
 )]
 // PrintEvent predicate tests
 #[test_case(
-    vec![vec![get_test_event_by_type("smart_contract_print_event")]], 
+    vec![vec![get_test_event_by_type("smart_contract_print_event")]],
     StacksPredicate::PrintEvent(StacksPrintEventBasedPredicate::Contains {
         contract_identifier: "ST3AXH4EBHD63FCFPTZ8GR29TNTVWDYPGY0KDY5E5.loan-data".to_string(),
         contains: "some-value".to_string()
@@ -273,7 +275,7 @@ pub mod fixtures;
     "PrintEvent predicate matches contract_identifier and contains"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("smart_contract_not_print_event")]], 
+    vec![vec![get_test_event_by_type("smart_contract_not_print_event")]],
     StacksPredicate::PrintEvent(StacksPrintEventBasedPredicate::Contains {
         contract_identifier: "ST3AXH4EBHD63FCFPTZ8GR29TNTVWDYPGY0KDY5E5.loan-data".to_string(),
         contains: "some-value".to_string(),
@@ -282,7 +284,7 @@ pub mod fixtures;
     "PrintEvent predicate does not check events with topic other than print"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("smart_contract_print_event")]], 
+    vec![vec![get_test_event_by_type("smart_contract_print_event")]],
     StacksPredicate::PrintEvent(StacksPrintEventBasedPredicate::Contains {
         contract_identifier: "wront-id".to_string(),
         contains: "some-value".to_string(),
@@ -291,7 +293,7 @@ pub mod fixtures;
     "PrintEvent predicate rejects non matching contract_identifier"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("smart_contract_print_event")]], 
+    vec![vec![get_test_event_by_type("smart_contract_print_event")]],
     StacksPredicate::PrintEvent(StacksPrintEventBasedPredicate::Contains {
         contract_identifier:
             "ST3AXH4EBHD63FCFPTZ8GR29TNTVWDYPGY0KDY5E5.loan-data".to_string(),
@@ -301,7 +303,7 @@ pub mod fixtures;
     "PrintEvent predicate rejects non matching contains value"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("smart_contract_print_event")]], 
+    vec![vec![get_test_event_by_type("smart_contract_print_event")]],
     StacksPredicate::PrintEvent(StacksPrintEventBasedPredicate::Contains {
         contract_identifier: "*".to_string(),
         contains: "some-value".to_string(),
@@ -310,7 +312,7 @@ pub mod fixtures;
     "PrintEvent predicate contract_identifier wildcard checks all print events for match"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("smart_contract_print_event")]], 
+    vec![vec![get_test_event_by_type("smart_contract_print_event")]],
     StacksPredicate::PrintEvent(StacksPrintEventBasedPredicate::Contains {
         contract_identifier: "ST3AXH4EBHD63FCFPTZ8GR29TNTVWDYPGY0KDY5E5.loan-data".to_string(),
         contains: "*".to_string(),
@@ -319,7 +321,7 @@ pub mod fixtures;
     "PrintEvent predicate contains wildcard matches all values for matching events"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("smart_contract_print_event")], vec![get_test_event_by_type("smart_contract_print_event_empty")]], 
+    vec![vec![get_test_event_by_type("smart_contract_print_event")], vec![get_test_event_by_type("smart_contract_print_event_empty")]],
     StacksPredicate::PrintEvent(StacksPrintEventBasedPredicate::Contains {
         contract_identifier: "*".to_string(),
         contains: "*".to_string(),
@@ -328,7 +330,7 @@ pub mod fixtures;
     "PrintEvent predicate contract_identifier wildcard and contains wildcard matches all values on all print events"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("smart_contract_print_event")]], 
+    vec![vec![get_test_event_by_type("smart_contract_print_event")]],
     StacksPredicate::PrintEvent(StacksPrintEventBasedPredicate::MatchesRegex {
         contract_identifier: "ST3AXH4EBHD63FCFPTZ8GR29TNTVWDYPGY0KDY5E5.loan-data".to_string(),
         regex: "(some)|(value)".to_string(),
@@ -337,7 +339,7 @@ pub mod fixtures;
     "PrintEvent predicate matches contract_identifier and regex"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("smart_contract_print_event")]], 
+    vec![vec![get_test_event_by_type("smart_contract_print_event")]],
     StacksPredicate::PrintEvent(StacksPrintEventBasedPredicate::MatchesRegex {
         contract_identifier: "*".to_string(),
         regex: "(some)|(value)".to_string(),
@@ -346,7 +348,7 @@ pub mod fixtures;
     "PrintEvent predicate contract_identifier wildcard checks all print events for match with regex"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("smart_contract_print_event")]], 
+    vec![vec![get_test_event_by_type("smart_contract_print_event")]],
     StacksPredicate::PrintEvent(StacksPrintEventBasedPredicate::MatchesRegex {
         contract_identifier: "*".to_string(),
         regex: "[".to_string(),
@@ -406,7 +408,7 @@ fn test_stacks_predicates(
 }
 
 #[test_case(
-    StacksPredicate::ContractDeployment(StacksContractDeploymentPredicate::Deployer("ST13F481SBR0R7Z6NMMH8YV2FJJYXA5JPA0AD3HP9".to_string())), 
+    StacksPredicate::ContractDeployment(StacksContractDeploymentPredicate::Deployer("ST13F481SBR0R7Z6NMMH8YV2FJJYXA5JPA0AD3HP9".to_string())),
     1;
     "Deployer predicate matches by contract deployer"
 )]
@@ -620,12 +622,12 @@ fn verify_optional_addition_of_contract_abi() {
     "ContractCall predicate does not match for wrong contract identifier"
 )]
 #[test_case(
-    StacksPredicate::Txid(ExactMatchingRule::Equals("0xb92c2ade84a8b85f4c72170680ae42e65438aea4db72ba4b2d6a6960f4141ce8".to_string())), 
+    StacksPredicate::Txid(ExactMatchingRule::Equals("0xb92c2ade84a8b85f4c72170680ae42e65438aea4db72ba4b2d6a6960f4141ce8".to_string())),
     1;
     "Txid predicate matches by a transaction's id"
 )]
 #[test_case(
-    StacksPredicate::Txid(ExactMatchingRule::Equals("wrong-id".to_string())), 
+    StacksPredicate::Txid(ExactMatchingRule::Equals("wrong-id".to_string())),
     0;
     "Txid predicate rejects non matching id"
 )]

--- a/components/chainhook-sdk/src/chainhooks/tests/mod.rs
+++ b/components/chainhook-sdk/src/chainhooks/tests/mod.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use self::fixtures::get_all_event_types;
+use self::fixtures::get_all_event_payload_types;
 
 use super::{
     stacks::{
@@ -17,7 +17,7 @@ use super::{
 use crate::{chainhooks::stacks::serialize_stacks_payload_to_json, utils::Context};
 use crate::{
     chainhooks::{
-        tests::fixtures::{get_expected_occurrence, get_test_event_by_type},
+        tests::fixtures::{get_expected_occurrence, get_test_event_payload_by_type},
         types::{HookAction, StacksPredicate, StacksStxEventBasedPredicate},
     },
     utils::AbstractStacksBlock,
@@ -25,6 +25,7 @@ use crate::{
 use chainhook_types::{
     StacksBlockUpdate, StacksChainEvent, StacksChainUpdatedWithBlocksData, StacksNetwork,
     StacksTransactionData, StacksTransactionEvent, StacksTransactionEventPayload,
+    StacksTransactionEventPosition,
 };
 use serde_json::Value as JsonValue;
 use test_case::test_case;
@@ -33,7 +34,7 @@ pub mod fixtures;
 
 // FtEvent predicate tests
 #[test_case(
-    vec![vec![get_test_event_by_type("ft_mint")]],
+    vec![vec![get_test_event_payload_by_type("ft_mint")]],
     StacksPredicate::FtEvent(StacksFtEventBasedPredicate {
         asset_identifier: "asset-id".to_string(),
         actions: vec!["mint".to_string()]
@@ -42,7 +43,7 @@ pub mod fixtures;
     "FtEvent predicates match mint event"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("ft_transfer")]],
+    vec![vec![get_test_event_payload_by_type("ft_transfer")]],
     StacksPredicate::FtEvent(StacksFtEventBasedPredicate {
         asset_identifier: "asset-id".to_string(),
         actions: vec!["transfer".to_string()]
@@ -70,7 +71,7 @@ pub mod fixtures;
     "FtEvent predicates match transfer event if matching event is not first in transaction"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("ft_burn")]],
+    vec![vec![get_test_event_payload_by_type("ft_burn")]],
     StacksPredicate::FtEvent(StacksFtEventBasedPredicate {
         asset_identifier: "asset-id".to_string(),
         actions: vec!["burn".to_string()]
@@ -79,7 +80,7 @@ pub mod fixtures;
     "FtEvent predicates match burn event"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("ft_mint")]],
+    vec![vec![get_test_event_payload_by_type("ft_mint")]],
     StacksPredicate::FtEvent(StacksFtEventBasedPredicate {
         asset_identifier: "wrong-id".to_string(),
         actions: vec!["mint".to_string()]
@@ -88,7 +89,7 @@ pub mod fixtures;
     "FtEvent predicates reject no-match asset id for mint event"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("ft_transfer")]],
+    vec![vec![get_test_event_payload_by_type("ft_transfer")]],
     StacksPredicate::FtEvent(StacksFtEventBasedPredicate {
         asset_identifier: "wrong-id".to_string(),
         actions: vec!["transfer".to_string()]
@@ -97,7 +98,7 @@ pub mod fixtures;
     "FtEvent predicates reject no-match asset id for transfer event"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("ft_burn")]],
+    vec![vec![get_test_event_payload_by_type("ft_burn")]],
     StacksPredicate::FtEvent(StacksFtEventBasedPredicate {
         asset_identifier: "wrong-id".to_string(),
         actions: vec!["burn".to_string()]
@@ -106,7 +107,7 @@ pub mod fixtures;
     "FtEvent predicates reject no-match asset id for burn event"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("ft_mint")],vec![get_test_event_by_type("ft_transfer")],vec![get_test_event_by_type("ft_burn")]],
+    vec![vec![get_test_event_payload_by_type("ft_mint")],vec![get_test_event_payload_by_type("ft_transfer")],vec![get_test_event_payload_by_type("ft_burn")]],
     StacksPredicate::FtEvent(StacksFtEventBasedPredicate {
         asset_identifier: "asset-id".to_string(),
         actions: vec!["mint".to_string(),"transfer".to_string(), "burn".to_string()]
@@ -115,7 +116,7 @@ pub mod fixtures;
     "FtEvent predicates match multiple events"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("ft_transfer")],vec![get_test_event_by_type("ft_burn")]],
+    vec![vec![get_test_event_payload_by_type("ft_transfer")],vec![get_test_event_payload_by_type("ft_burn")]],
     StacksPredicate::FtEvent(StacksFtEventBasedPredicate {
         asset_identifier: "asset-id".to_string(),
         actions: vec!["mint".to_string()]
@@ -125,7 +126,7 @@ pub mod fixtures;
 )]
 // NftEvent predicate tests
 #[test_case(
-    vec![vec![get_test_event_by_type("nft_mint")]],
+    vec![vec![get_test_event_payload_by_type("nft_mint")]],
     StacksPredicate::NftEvent(StacksNftEventBasedPredicate {
         asset_identifier: "asset-id".to_string(),
         actions: vec!["mint".to_string()]
@@ -134,7 +135,7 @@ pub mod fixtures;
     "NftEvent predicates match mint event"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("nft_transfer")]],
+    vec![vec![get_test_event_payload_by_type("nft_transfer")]],
     StacksPredicate::NftEvent(StacksNftEventBasedPredicate {
         asset_identifier: "asset-id".to_string(),
         actions: vec!["transfer".to_string()]
@@ -162,7 +163,7 @@ pub mod fixtures;
     "NftEvent predicates match transfer event if matching event is not first in transaction"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("nft_burn")]],
+    vec![vec![get_test_event_payload_by_type("nft_burn")]],
     StacksPredicate::NftEvent(StacksNftEventBasedPredicate {
         asset_identifier: "asset-id".to_string(),
         actions: vec!["burn".to_string()]
@@ -171,7 +172,7 @@ pub mod fixtures;
     "NftEvent predicates match burn event"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("nft_mint")]],
+    vec![vec![get_test_event_payload_by_type("nft_mint")]],
     StacksPredicate::NftEvent(StacksNftEventBasedPredicate {
         asset_identifier: "wrong-id".to_string(),
         actions: vec!["mint".to_string()]
@@ -180,7 +181,7 @@ pub mod fixtures;
     "NftEvent predicates reject no-match asset id for mint event"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("nft_transfer")]],
+    vec![vec![get_test_event_payload_by_type("nft_transfer")]],
     StacksPredicate::NftEvent(StacksNftEventBasedPredicate {
         asset_identifier: "wrong-id".to_string(),
         actions: vec!["transfer".to_string()]
@@ -189,7 +190,7 @@ pub mod fixtures;
     "NftEvent predicates reject no-match asset id for transfer event"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("nft_burn")]],
+    vec![vec![get_test_event_payload_by_type("nft_burn")]],
     StacksPredicate::NftEvent(StacksNftEventBasedPredicate {
         asset_identifier: "wrong-id".to_string(),
         actions: vec!["burn".to_string()]
@@ -198,7 +199,7 @@ pub mod fixtures;
     "NftEvent predicates reject no-match asset id for burn event"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("nft_mint")],vec![get_test_event_by_type("nft_transfer")],vec![get_test_event_by_type("nft_burn")]],
+    vec![vec![get_test_event_payload_by_type("nft_mint")],vec![get_test_event_payload_by_type("nft_transfer")],vec![get_test_event_payload_by_type("nft_burn")]],
     StacksPredicate::NftEvent(StacksNftEventBasedPredicate {
         asset_identifier: "asset-id".to_string(),
         actions: vec!["mint".to_string(),"transfer".to_string(), "burn".to_string()]
@@ -207,7 +208,7 @@ pub mod fixtures;
     "NftEvent predicates match multiple events"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("nft_transfer")],vec![get_test_event_by_type("nft_burn")]],
+    vec![vec![get_test_event_payload_by_type("nft_transfer")],vec![get_test_event_payload_by_type("nft_burn")]],
     StacksPredicate::NftEvent(StacksNftEventBasedPredicate {
         asset_identifier: "asset-id".to_string(),
         actions: vec!["mint".to_string()]
@@ -217,7 +218,7 @@ pub mod fixtures;
 )]
 // StxEvent predicate tests
 #[test_case(
-    vec![vec![get_test_event_by_type("stx_mint")]],
+    vec![vec![get_test_event_payload_by_type("stx_mint")]],
     StacksPredicate::StxEvent(StacksStxEventBasedPredicate {
         actions: vec!["mint".to_string()]
     }),
@@ -225,7 +226,7 @@ pub mod fixtures;
     "StxEvent predicates match mint event"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("stx_transfer")]],
+    vec![vec![get_test_event_payload_by_type("stx_transfer")]],
     StacksPredicate::StxEvent(StacksStxEventBasedPredicate {
         actions: vec!["transfer".to_string()]
     }),
@@ -233,7 +234,7 @@ pub mod fixtures;
     "StxEvent predicates match transfer event"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("stx_lock")]],
+    vec![vec![get_test_event_payload_by_type("stx_lock")]],
     StacksPredicate::StxEvent(StacksStxEventBasedPredicate {
         actions: vec!["lock".to_string()]
     }),
@@ -241,7 +242,7 @@ pub mod fixtures;
     "StxEvent predicates match lock event"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("stx_burn")]],
+    vec![vec![get_test_event_payload_by_type("stx_burn")]],
     StacksPredicate::StxEvent(StacksStxEventBasedPredicate {
         actions: vec!["burn".to_string()]
     }),
@@ -249,7 +250,7 @@ pub mod fixtures;
     "StxEvent predicates match burn event"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("stx_mint")],vec![get_test_event_by_type("stx_transfer")],vec![get_test_event_by_type("stx_lock")]],
+    vec![vec![get_test_event_payload_by_type("stx_mint")],vec![get_test_event_payload_by_type("stx_transfer")],vec![get_test_event_payload_by_type("stx_lock")]],
     StacksPredicate::StxEvent(StacksStxEventBasedPredicate {
         actions: vec!["mint".to_string(), "transfer".to_string(), "lock".to_string()]
     }),
@@ -257,7 +258,7 @@ pub mod fixtures;
     "StxEvent predicates match multiple events"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("stx_transfer")],vec![get_test_event_by_type("stx_lock")]],
+    vec![vec![get_test_event_payload_by_type("stx_transfer")],vec![get_test_event_payload_by_type("stx_lock")]],
     StacksPredicate::StxEvent(StacksStxEventBasedPredicate {
         actions: vec!["mint".to_string()]
     }),
@@ -266,7 +267,7 @@ pub mod fixtures;
 )]
 // PrintEvent predicate tests
 #[test_case(
-    vec![vec![get_test_event_by_type("smart_contract_print_event")]],
+    vec![vec![get_test_event_payload_by_type("smart_contract_print_event")]],
     StacksPredicate::PrintEvent(StacksPrintEventBasedPredicate::Contains {
         contract_identifier: "ST3AXH4EBHD63FCFPTZ8GR29TNTVWDYPGY0KDY5E5.loan-data".to_string(),
         contains: "some-value".to_string()
@@ -275,7 +276,7 @@ pub mod fixtures;
     "PrintEvent predicate matches contract_identifier and contains"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("smart_contract_not_print_event")]],
+    vec![vec![get_test_event_payload_by_type("smart_contract_not_print_event")]],
     StacksPredicate::PrintEvent(StacksPrintEventBasedPredicate::Contains {
         contract_identifier: "ST3AXH4EBHD63FCFPTZ8GR29TNTVWDYPGY0KDY5E5.loan-data".to_string(),
         contains: "some-value".to_string(),
@@ -284,7 +285,7 @@ pub mod fixtures;
     "PrintEvent predicate does not check events with topic other than print"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("smart_contract_print_event")]],
+    vec![vec![get_test_event_payload_by_type("smart_contract_print_event")]],
     StacksPredicate::PrintEvent(StacksPrintEventBasedPredicate::Contains {
         contract_identifier: "wront-id".to_string(),
         contains: "some-value".to_string(),
@@ -293,7 +294,7 @@ pub mod fixtures;
     "PrintEvent predicate rejects non matching contract_identifier"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("smart_contract_print_event")]],
+    vec![vec![get_test_event_payload_by_type("smart_contract_print_event")]],
     StacksPredicate::PrintEvent(StacksPrintEventBasedPredicate::Contains {
         contract_identifier:
             "ST3AXH4EBHD63FCFPTZ8GR29TNTVWDYPGY0KDY5E5.loan-data".to_string(),
@@ -303,7 +304,7 @@ pub mod fixtures;
     "PrintEvent predicate rejects non matching contains value"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("smart_contract_print_event")]],
+    vec![vec![get_test_event_payload_by_type("smart_contract_print_event")]],
     StacksPredicate::PrintEvent(StacksPrintEventBasedPredicate::Contains {
         contract_identifier: "*".to_string(),
         contains: "some-value".to_string(),
@@ -312,7 +313,7 @@ pub mod fixtures;
     "PrintEvent predicate contract_identifier wildcard checks all print events for match"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("smart_contract_print_event")]],
+    vec![vec![get_test_event_payload_by_type("smart_contract_print_event")]],
     StacksPredicate::PrintEvent(StacksPrintEventBasedPredicate::Contains {
         contract_identifier: "ST3AXH4EBHD63FCFPTZ8GR29TNTVWDYPGY0KDY5E5.loan-data".to_string(),
         contains: "*".to_string(),
@@ -321,7 +322,7 @@ pub mod fixtures;
     "PrintEvent predicate contains wildcard matches all values for matching events"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("smart_contract_print_event")], vec![get_test_event_by_type("smart_contract_print_event_empty")]],
+    vec![vec![get_test_event_payload_by_type("smart_contract_print_event")], vec![get_test_event_payload_by_type("smart_contract_print_event_empty")]],
     StacksPredicate::PrintEvent(StacksPrintEventBasedPredicate::Contains {
         contract_identifier: "*".to_string(),
         contains: "*".to_string(),
@@ -330,7 +331,7 @@ pub mod fixtures;
     "PrintEvent predicate contract_identifier wildcard and contains wildcard matches all values on all print events"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("smart_contract_print_event")]],
+    vec![vec![get_test_event_payload_by_type("smart_contract_print_event")]],
     StacksPredicate::PrintEvent(StacksPrintEventBasedPredicate::MatchesRegex {
         contract_identifier: "ST3AXH4EBHD63FCFPTZ8GR29TNTVWDYPGY0KDY5E5.loan-data".to_string(),
         regex: "(some)|(value)".to_string(),
@@ -339,7 +340,7 @@ pub mod fixtures;
     "PrintEvent predicate matches contract_identifier and regex"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("smart_contract_print_event")]],
+    vec![vec![get_test_event_payload_by_type("smart_contract_print_event")]],
     StacksPredicate::PrintEvent(StacksPrintEventBasedPredicate::MatchesRegex {
         contract_identifier: "*".to_string(),
         regex: "(some)|(value)".to_string(),
@@ -348,7 +349,7 @@ pub mod fixtures;
     "PrintEvent predicate contract_identifier wildcard checks all print events for match with regex"
 )]
 #[test_case(
-    vec![vec![get_test_event_by_type("smart_contract_print_event")]],
+    vec![vec![get_test_event_payload_by_type("smart_contract_print_event")]],
     StacksPredicate::PrintEvent(StacksPrintEventBasedPredicate::MatchesRegex {
         contract_identifier: "*".to_string(),
         regex: "[".to_string(),
@@ -358,15 +359,27 @@ pub mod fixtures;
     "PrintEvent predicate does not match invalid regex"
 )]
 fn test_stacks_predicates(
-    blocks_with_events: Vec<Vec<StacksTransactionEvent>>,
+    blocks_with_events: Vec<Vec<StacksTransactionEventPayload>>,
     predicate: StacksPredicate,
     expected_applies: u64,
 ) {
     // Prepare block
     let new_blocks = blocks_with_events
-        .iter()
-        .map(|events| StacksBlockUpdate {
-            block: fixtures::build_stacks_testnet_block_from_smart_contract_event_data(events),
+        .into_iter()
+        .map(|payloads| StacksBlockUpdate {
+            block: fixtures::build_stacks_testnet_block_from_smart_contract_event_data(
+                payloads
+                    .into_iter()
+                    .enumerate()
+                    .map(|(index, payload)| StacksTransactionEvent {
+                        event_payload: payload,
+                        position: StacksTransactionEventPosition {
+                            index: index as u32,
+                        },
+                    })
+                    .collect::<Vec<_>>()
+                    .as_ref(),
+            ),
             parent_microblocks_to_apply: vec![],
             parent_microblocks_to_rollback: vec![],
         })
@@ -765,15 +778,18 @@ fn test_stacks_hook_action_file_append() {
         enabled: true,
         expired_at: None,
     };
-    let events = get_all_event_types();
-    let mut apply_blocks = vec![];
-    for event in events.iter() {
-        apply_blocks.push(
+    let payloads = get_all_event_payload_types();
+    let apply_blocks = payloads
+        .into_iter()
+        .map(|payload| {
             fixtures::build_stacks_testnet_block_from_smart_contract_event_data(&vec![
-                event.to_owned()
-            ]),
-        );
-    }
+                StacksTransactionEvent {
+                    event_payload: payload,
+                    position: StacksTransactionEventPosition { index: 0 },
+                },
+            ])
+        })
+        .collect::<Vec<_>>();
     let apply: Vec<(Vec<&StacksTransactionData>, &dyn AbstractStacksBlock)> = apply_blocks
         .iter()
         .map(|b| {

--- a/components/chainhook-sdk/src/indexer/stacks/mod.rs
+++ b/components/chainhook-sdk/src/indexer/stacks/mod.rs
@@ -122,63 +122,138 @@ impl NewEvent {
         if let Some(ref event_data) = self.stx_mint_event {
             let data: STXMintEventData =
                 serde_json::from_value(event_data.clone()).expect("Unable to decode event_data");
-            return Ok(StacksTransactionEvent::STXMintEvent(data.clone()));
+            return Ok(StacksTransactionEvent {
+                event_payload: (StacksTransactionEventPayload::STXMintEvent(data)),
+                position: StacksTransactionEventPosition {
+                    index: self.event_index,
+                },
+            });
         } else if let Some(ref event_data) = self.stx_lock_event {
             let data: STXLockEventData =
                 serde_json::from_value(event_data.clone()).expect("Unable to decode event_data");
-            return Ok(StacksTransactionEvent::STXLockEvent(data.clone()));
+            return Ok(StacksTransactionEvent {
+                event_payload: (StacksTransactionEventPayload::STXLockEvent(data)),
+                position: StacksTransactionEventPosition {
+                    index: self.event_index,
+                },
+            });
         } else if let Some(ref event_data) = self.stx_burn_event {
             let data: STXBurnEventData =
                 serde_json::from_value(event_data.clone()).expect("Unable to decode event_data");
-            return Ok(StacksTransactionEvent::STXBurnEvent(data.clone()));
+            return Ok(StacksTransactionEvent {
+                event_payload: (StacksTransactionEventPayload::STXBurnEvent(data)),
+                position: StacksTransactionEventPosition {
+                    index: self.event_index,
+                },
+            });
         } else if let Some(ref event_data) = self.stx_transfer_event {
             let data: STXTransferEventData =
                 serde_json::from_value(event_data.clone()).expect("Unable to decode event_data");
-            return Ok(StacksTransactionEvent::STXTransferEvent(data.clone()));
+            return Ok(StacksTransactionEvent {
+                event_payload: StacksTransactionEventPayload::STXTransferEvent(data.clone()),
+                position: StacksTransactionEventPosition {
+                    index: self.event_index,
+                },
+            });
         } else if let Some(ref event_data) = self.nft_mint_event {
             let data: NFTMintEventData =
                 serde_json::from_value(event_data.clone()).expect("Unable to decode event_data");
-            return Ok(StacksTransactionEvent::NFTMintEvent(data.clone()));
+            return Ok(StacksTransactionEvent {
+                event_payload: (StacksTransactionEventPayload::NFTMintEvent(data)),
+                position: StacksTransactionEventPosition {
+                    index: self.event_index,
+                },
+            });
         } else if let Some(ref event_data) = self.nft_burn_event {
             let data: NFTBurnEventData =
                 serde_json::from_value(event_data.clone()).expect("Unable to decode event_data");
-            return Ok(StacksTransactionEvent::NFTBurnEvent(data.clone()));
+            return Ok(StacksTransactionEvent {
+                event_payload: (StacksTransactionEventPayload::NFTBurnEvent(data)),
+                position: StacksTransactionEventPosition {
+                    index: self.event_index,
+                },
+            });
         } else if let Some(ref event_data) = self.nft_transfer_event {
             let data: NFTTransferEventData =
                 serde_json::from_value(event_data.clone()).expect("Unable to decode event_data");
-            return Ok(StacksTransactionEvent::NFTTransferEvent(data.clone()));
+            return Ok(StacksTransactionEvent {
+                event_payload: StacksTransactionEventPayload::NFTTransferEvent(data.clone()),
+                position: StacksTransactionEventPosition {
+                    index: self.event_index,
+                },
+            });
         } else if let Some(ref event_data) = self.ft_mint_event {
             let data: FTMintEventData =
                 serde_json::from_value(event_data.clone()).expect("Unable to decode event_data");
-            return Ok(StacksTransactionEvent::FTMintEvent(data.clone()));
+            return Ok(StacksTransactionEvent {
+                event_payload: (StacksTransactionEventPayload::FTMintEvent(data)),
+                position: StacksTransactionEventPosition {
+                    index: self.event_index,
+                },
+            });
         } else if let Some(ref event_data) = self.ft_burn_event {
             let data: FTBurnEventData =
                 serde_json::from_value(event_data.clone()).expect("Unable to decode event_data");
-            return Ok(StacksTransactionEvent::FTBurnEvent(data.clone()));
+            return Ok(StacksTransactionEvent {
+                event_payload: (StacksTransactionEventPayload::FTBurnEvent(data)),
+                position: StacksTransactionEventPosition {
+                    index: self.event_index,
+                },
+            });
         } else if let Some(ref event_data) = self.ft_transfer_event {
             let data: FTTransferEventData =
                 serde_json::from_value(event_data.clone()).expect("Unable to decode event_data");
-            return Ok(StacksTransactionEvent::FTTransferEvent(data.clone()));
+            return Ok(StacksTransactionEvent {
+                event_payload: (StacksTransactionEventPayload::FTTransferEvent(data)),
+                position: StacksTransactionEventPosition {
+                    index: self.event_index,
+                },
+            });
         } else if let Some(ref event_data) = self.data_var_set_event {
             let data: DataVarSetEventData =
                 serde_json::from_value(event_data.clone()).expect("Unable to decode event_data");
-            return Ok(StacksTransactionEvent::DataVarSetEvent(data.clone()));
+            return Ok(StacksTransactionEvent {
+                event_payload: (StacksTransactionEventPayload::DataVarSetEvent(data)),
+                position: StacksTransactionEventPosition {
+                    index: self.event_index,
+                },
+            });
         } else if let Some(ref event_data) = self.data_map_insert_event {
             let data: DataMapInsertEventData =
                 serde_json::from_value(event_data.clone()).expect("Unable to decode event_data");
-            return Ok(StacksTransactionEvent::DataMapInsertEvent(data.clone()));
+            return Ok(StacksTransactionEvent {
+                event_payload: StacksTransactionEventPayload::DataMapInsertEvent(data.clone()),
+                position: StacksTransactionEventPosition {
+                    index: self.event_index,
+                },
+            });
         } else if let Some(ref event_data) = self.data_map_update_event {
             let data: DataMapUpdateEventData =
                 serde_json::from_value(event_data.clone()).expect("Unable to decode event_data");
-            return Ok(StacksTransactionEvent::DataMapUpdateEvent(data.clone()));
+            return Ok(StacksTransactionEvent {
+                event_payload: StacksTransactionEventPayload::DataMapUpdateEvent(data.clone()),
+                position: StacksTransactionEventPosition {
+                    index: self.event_index,
+                },
+            });
         } else if let Some(ref event_data) = self.data_map_delete_event {
             let data: DataMapDeleteEventData =
                 serde_json::from_value(event_data.clone()).expect("Unable to decode event_data");
-            return Ok(StacksTransactionEvent::DataMapDeleteEvent(data.clone()));
+            return Ok(StacksTransactionEvent {
+                event_payload: StacksTransactionEventPayload::DataMapDeleteEvent(data.clone()),
+                position: StacksTransactionEventPosition {
+                    index: self.event_index,
+                },
+            });
         } else if let Some(ref event_data) = self.contract_event {
             let data: SmartContractEventData =
                 serde_json::from_value(event_data.clone()).expect("Unable to decode event_data");
-            return Ok(StacksTransactionEvent::SmartContractEvent(data.clone()));
+            return Ok(StacksTransactionEvent {
+                event_payload: StacksTransactionEventPayload::SmartContractEvent(data.clone()),
+                position: StacksTransactionEventPosition {
+                    index: self.event_index,
+                },
+            });
         }
         return Err(format!("unable to support event type"));
     }
@@ -842,8 +917,8 @@ pub fn get_standardized_stacks_receipt(
     if include_operations {
         let mut operation_id = 0;
         for event in events.iter() {
-            match event {
-                StacksTransactionEvent::STXMintEvent(data) => {
+            match &event.event_payload {
+                StacksTransactionEventPayload::STXMintEvent(data) => {
                     operations.push(Operation {
                         operation_identifier: OperationIdentifier {
                             index: operation_id,
@@ -864,7 +939,7 @@ pub fn get_standardized_stacks_receipt(
                     });
                     operation_id += 1;
                 }
-                StacksTransactionEvent::STXLockEvent(data) => {
+                StacksTransactionEventPayload::STXLockEvent(data) => {
                     operations.push(Operation {
                         operation_identifier: OperationIdentifier {
                             index: operation_id,
@@ -888,7 +963,7 @@ pub fn get_standardized_stacks_receipt(
                     });
                     operation_id += 1;
                 }
-                StacksTransactionEvent::STXBurnEvent(data) => {
+                StacksTransactionEventPayload::STXBurnEvent(data) => {
                     operations.push(Operation {
                         operation_identifier: OperationIdentifier {
                             index: operation_id,
@@ -909,7 +984,7 @@ pub fn get_standardized_stacks_receipt(
                     });
                     operation_id += 1;
                 }
-                StacksTransactionEvent::STXTransferEvent(data) => {
+                StacksTransactionEventPayload::STXTransferEvent(data) => {
                     operations.push(Operation {
                         operation_identifier: OperationIdentifier {
                             index: operation_id,
@@ -955,7 +1030,7 @@ pub fn get_standardized_stacks_receipt(
                     });
                     operation_id += 1;
                 }
-                StacksTransactionEvent::NFTMintEvent(data) => {
+                StacksTransactionEventPayload::NFTMintEvent(data) => {
                     let (asset_class_identifier, contract_identifier) =
                         get_mutated_ids(&data.asset_class_identifier);
                     mutated_assets_radius.insert(asset_class_identifier);
@@ -983,7 +1058,7 @@ pub fn get_standardized_stacks_receipt(
                     });
                     operation_id += 1;
                 }
-                StacksTransactionEvent::NFTBurnEvent(data) => {
+                StacksTransactionEventPayload::NFTBurnEvent(data) => {
                     let (asset_class_identifier, contract_identifier) =
                         get_mutated_ids(&data.asset_class_identifier);
                     mutated_assets_radius.insert(asset_class_identifier);
@@ -1011,7 +1086,7 @@ pub fn get_standardized_stacks_receipt(
                     });
                     operation_id += 1;
                 }
-                StacksTransactionEvent::NFTTransferEvent(data) => {
+                StacksTransactionEventPayload::NFTTransferEvent(data) => {
                     let (asset_class_identifier, contract_identifier) =
                         get_mutated_ids(&data.asset_class_identifier);
                     mutated_assets_radius.insert(asset_class_identifier);
@@ -1064,7 +1139,7 @@ pub fn get_standardized_stacks_receipt(
                     });
                     operation_id += 1;
                 }
-                StacksTransactionEvent::FTMintEvent(data) => {
+                StacksTransactionEventPayload::FTMintEvent(data) => {
                     let (asset_class_identifier, contract_identifier) =
                         get_mutated_ids(&data.asset_class_identifier);
                     mutated_assets_radius.insert(asset_class_identifier);
@@ -1100,7 +1175,7 @@ pub fn get_standardized_stacks_receipt(
                     });
                     operation_id += 1;
                 }
-                StacksTransactionEvent::FTBurnEvent(data) => {
+                StacksTransactionEventPayload::FTBurnEvent(data) => {
                     let (asset_class_identifier, contract_identifier) =
                         get_mutated_ids(&data.asset_class_identifier);
                     mutated_assets_radius.insert(asset_class_identifier);
@@ -1131,7 +1206,7 @@ pub fn get_standardized_stacks_receipt(
                     });
                     operation_id += 1;
                 }
-                StacksTransactionEvent::FTTransferEvent(data) => {
+                StacksTransactionEventPayload::FTTransferEvent(data) => {
                     let (asset_class_identifier, contract_identifier) =
                         get_mutated_ids(&data.asset_class_identifier);
                     mutated_assets_radius.insert(asset_class_identifier);
@@ -1187,11 +1262,11 @@ pub fn get_standardized_stacks_receipt(
                     });
                     operation_id += 1;
                 }
-                StacksTransactionEvent::DataVarSetEvent(_data) => {}
-                StacksTransactionEvent::DataMapInsertEvent(_data) => {}
-                StacksTransactionEvent::DataMapUpdateEvent(_data) => {}
-                StacksTransactionEvent::DataMapDeleteEvent(_data) => {}
-                StacksTransactionEvent::SmartContractEvent(data) => {
+                StacksTransactionEventPayload::DataVarSetEvent(_data) => {}
+                StacksTransactionEventPayload::DataMapInsertEvent(_data) => {}
+                StacksTransactionEventPayload::DataMapUpdateEvent(_data) => {}
+                StacksTransactionEventPayload::DataMapDeleteEvent(_data) => {}
+                StacksTransactionEventPayload::SmartContractEvent(data) => {
                     mutated_contracts_radius.insert(data.contract_identifier.clone());
                 }
             }

--- a/components/chainhook-sdk/src/indexer/stacks/tests.rs
+++ b/components/chainhook-sdk/src/indexer/stacks/tests.rs
@@ -2,7 +2,7 @@ use chainhook_types::{
     DataMapDeleteEventData, DataMapInsertEventData, DataMapUpdateEventData, DataVarSetEventData,
     FTBurnEventData, FTMintEventData, FTTransferEventData, NFTBurnEventData, NFTMintEventData,
     NFTTransferEventData, STXBurnEventData, STXLockEventData, STXMintEventData,
-    STXTransferEventData, SmartContractEventData, StacksTransactionEvent,
+    STXTransferEventData, SmartContractEventData, StacksTransactionEventPayload,
 };
 
 use crate::indexer::tests::helpers::stacks_events::create_new_event_from_stacks_event;
@@ -273,88 +273,88 @@ fn test_stacks_vector_052() {
     process_stacks_blocks_and_check_expectations(helpers::stacks_shapes::get_vector_052());
 }
 
-#[test_case(StacksTransactionEvent::STXTransferEvent(STXTransferEventData {
+#[test_case(StacksTransactionEventPayload::STXTransferEvent(STXTransferEventData {
     sender: format!(""),
     recipient: format!(""),
     amount: format!("1"),
 }); "stx_transfer")]
-#[test_case(StacksTransactionEvent::STXMintEvent(STXMintEventData {
+#[test_case(StacksTransactionEventPayload::STXMintEvent(STXMintEventData {
     recipient: format!(""),
     amount: format!("1"),
 }); "stx_mint")]
-#[test_case(StacksTransactionEvent::STXBurnEvent(STXBurnEventData {
+#[test_case(StacksTransactionEventPayload::STXBurnEvent(STXBurnEventData {
     sender: format!(""),
     amount: format!("1"),
 }); "stx_burn")]
-#[test_case(StacksTransactionEvent::STXLockEvent(STXLockEventData {
+#[test_case(StacksTransactionEventPayload::STXLockEvent(STXLockEventData {
     locked_amount: format!("1"),
     unlock_height: format!(""),
     locked_address: format!(""),
 }); "stx_lock")]
-#[test_case(StacksTransactionEvent::NFTTransferEvent(NFTTransferEventData {
+#[test_case(StacksTransactionEventPayload::NFTTransferEvent(NFTTransferEventData {
     asset_class_identifier: format!(""),
     hex_asset_identifier: format!(""),
     sender: format!(""),
     recipient: format!(""),
 }); "nft_transfer")]
-#[test_case(StacksTransactionEvent::NFTMintEvent(NFTMintEventData {
+#[test_case(StacksTransactionEventPayload::NFTMintEvent(NFTMintEventData {
     asset_class_identifier: format!(""),
     hex_asset_identifier: format!(""),
     recipient: format!(""),
 }); "nft_mint")]
-#[test_case(StacksTransactionEvent::NFTBurnEvent(NFTBurnEventData {
+#[test_case(StacksTransactionEventPayload::NFTBurnEvent(NFTBurnEventData {
     asset_class_identifier: format!(""),
     hex_asset_identifier: format!(""),
     sender: format!(""),
 }); "nft_burn")]
-#[test_case(StacksTransactionEvent::FTTransferEvent(FTTransferEventData {
+#[test_case(StacksTransactionEventPayload::FTTransferEvent(FTTransferEventData {
     asset_class_identifier: format!(""),
     sender: format!(""),
     recipient: format!(""),
     amount: format!("1"),
 }); "ft_transfer")]
-#[test_case(StacksTransactionEvent::FTMintEvent(FTMintEventData {
+#[test_case(StacksTransactionEventPayload::FTMintEvent(FTMintEventData {
     asset_class_identifier: format!(""),
     recipient: format!(""),
     amount: format!("1"),
 }); "ft_mint")]
-#[test_case(StacksTransactionEvent::FTBurnEvent(FTBurnEventData {
+#[test_case(StacksTransactionEventPayload::FTBurnEvent(FTBurnEventData {
     asset_class_identifier: format!(""),
     sender: format!(""),
     amount: format!("1"),
 }); "ft_burn")]
-#[test_case(StacksTransactionEvent::DataVarSetEvent(DataVarSetEventData {
+#[test_case(StacksTransactionEventPayload::DataVarSetEvent(DataVarSetEventData {
     contract_identifier: format!(""),
     var: format!(""),
     hex_new_value: format!(""),
 }); "data_var_set")]
-#[test_case(StacksTransactionEvent::DataMapInsertEvent(DataMapInsertEventData {
+#[test_case(StacksTransactionEventPayload::DataMapInsertEvent(DataMapInsertEventData {
     contract_identifier: format!(""),
     hex_inserted_key: format!(""),
     hex_inserted_value: format!(""),
     map: format!("")
 }); "data_map_insert")]
-#[test_case(StacksTransactionEvent::DataMapUpdateEvent(DataMapUpdateEventData {
+#[test_case(StacksTransactionEventPayload::DataMapUpdateEvent(DataMapUpdateEventData {
     contract_identifier: format!(""),
     hex_new_value: format!(""),
     hex_key: format!(""),
     map: format!("")
 }); "data_map_update")]
-#[test_case(StacksTransactionEvent::DataMapDeleteEvent(DataMapDeleteEventData {
+#[test_case(StacksTransactionEventPayload::DataMapDeleteEvent(DataMapDeleteEventData {
     contract_identifier: format!(""),
     hex_deleted_key: format!(""),
     map: format!("")
 }); "data_map_delete")]
-#[test_case(StacksTransactionEvent::SmartContractEvent(SmartContractEventData {
+#[test_case(StacksTransactionEventPayload::SmartContractEvent(SmartContractEventData {
     contract_identifier: format!(""),
     topic: format!("print"),
     hex_value: format!(""),
 }); "smart_contract_print_event")]
-fn new_events_can_be_converted_into_chainhook_event(original_event: StacksTransactionEvent) {
+fn new_events_can_be_converted_into_chainhook_event(original_event: StacksTransactionEventPayload) {
     let new_event = create_new_event_from_stacks_event(original_event.clone());
     let event = new_event.into_chainhook_event().unwrap();
     let original_event_serialized = serde_json::to_string(&original_event).unwrap();
-    let event_serialized = serde_json::to_string(&event).unwrap();
+    let event_serialized = serde_json::to_string(&event.event_payload).unwrap();
     assert_eq!(original_event_serialized, event_serialized);
 }
 

--- a/components/chainhook-sdk/src/indexer/tests/helpers/stacks_events.rs
+++ b/components/chainhook-sdk/src/indexer/tests/helpers/stacks_events.rs
@@ -1,94 +1,97 @@
-use chainhook_types::StacksTransactionEvent;
+use chainhook_types::StacksTransactionEventPayload;
 
 use crate::indexer::stacks::NewEvent;
 
-pub fn create_new_event_from_stacks_event(event: StacksTransactionEvent) -> NewEvent {
+pub fn create_new_event_from_stacks_event(event: StacksTransactionEventPayload) -> NewEvent {
     let mut event_type = String::new();
-    let stx_transfer_event = if let StacksTransactionEvent::STXTransferEvent(data) = &event {
+    let stx_transfer_event = if let StacksTransactionEventPayload::STXTransferEvent(data) = &event {
         event_type = format!("stx_transfer");
         Some(serde_json::to_value(data).unwrap())
     } else {
         None
     };
-    let stx_mint_event = if let StacksTransactionEvent::STXMintEvent(data) = &event {
+    let stx_mint_event = if let StacksTransactionEventPayload::STXMintEvent(data) = &event {
         event_type = format!("stx_mint");
         Some(serde_json::to_value(data).unwrap())
     } else {
         None
     };
-    let stx_burn_event = if let StacksTransactionEvent::STXBurnEvent(data) = &event {
+    let stx_burn_event = if let StacksTransactionEventPayload::STXBurnEvent(data) = &event {
         event_type = format!("stx_burn");
         Some(serde_json::to_value(data).unwrap())
     } else {
         None
     };
-    let stx_lock_event = if let StacksTransactionEvent::STXLockEvent(data) = &event {
+    let stx_lock_event = if let StacksTransactionEventPayload::STXLockEvent(data) = &event {
         event_type = format!("stx_lock");
         Some(serde_json::to_value(data).unwrap())
     } else {
         None
     };
-    let nft_transfer_event = if let StacksTransactionEvent::NFTTransferEvent(data) = &event {
+    let nft_transfer_event = if let StacksTransactionEventPayload::NFTTransferEvent(data) = &event {
         event_type = format!("nft_transfer");
         Some(serde_json::to_value(data).unwrap())
     } else {
         None
     };
-    let nft_mint_event = if let StacksTransactionEvent::NFTMintEvent(data) = &event {
+    let nft_mint_event = if let StacksTransactionEventPayload::NFTMintEvent(data) = &event {
         event_type = format!("nft_mint");
         Some(serde_json::to_value(data).unwrap())
     } else {
         None
     };
-    let nft_burn_event = if let StacksTransactionEvent::NFTBurnEvent(data) = &event {
+    let nft_burn_event = if let StacksTransactionEventPayload::NFTBurnEvent(data) = &event {
         event_type = format!("nft_burn");
         Some(serde_json::to_value(data).unwrap())
     } else {
         None
     };
-    let ft_transfer_event = if let StacksTransactionEvent::FTTransferEvent(data) = &event {
+    let ft_transfer_event = if let StacksTransactionEventPayload::FTTransferEvent(data) = &event {
         event_type = format!("ft_transfer");
         Some(serde_json::to_value(data).unwrap())
     } else {
         None
     };
-    let ft_mint_event = if let StacksTransactionEvent::FTMintEvent(data) = &event {
+    let ft_mint_event = if let StacksTransactionEventPayload::FTMintEvent(data) = &event {
         event_type = format!("ft_mint");
         Some(serde_json::to_value(data).unwrap())
     } else {
         None
     };
-    let ft_burn_event = if let StacksTransactionEvent::FTBurnEvent(data) = &event {
+    let ft_burn_event = if let StacksTransactionEventPayload::FTBurnEvent(data) = &event {
         event_type = format!("ft_burn");
         Some(serde_json::to_value(data).unwrap())
     } else {
         None
     };
-    let data_var_set_event = if let StacksTransactionEvent::DataVarSetEvent(data) = &event {
+    let data_var_set_event = if let StacksTransactionEventPayload::DataVarSetEvent(data) = &event {
         event_type = format!("data_var_set");
         Some(serde_json::to_value(data).unwrap())
     } else {
         None
     };
-    let data_map_insert_event = if let StacksTransactionEvent::DataMapInsertEvent(data) = &event {
-        event_type = format!("data_map_insert");
-        Some(serde_json::to_value(data).unwrap())
-    } else {
-        None
-    };
-    let data_map_update_event = if let StacksTransactionEvent::DataMapUpdateEvent(data) = &event {
-        event_type = format!("data_map_update");
-        Some(serde_json::to_value(data).unwrap())
-    } else {
-        None
-    };
-    let data_map_delete_event = if let StacksTransactionEvent::DataMapDeleteEvent(data) = &event {
-        event_type = format!("data_map_delete");
-        Some(serde_json::to_value(data).unwrap())
-    } else {
-        None
-    };
-    let contract_event = if let StacksTransactionEvent::SmartContractEvent(data) = &event {
+    let data_map_insert_event =
+        if let StacksTransactionEventPayload::DataMapInsertEvent(data) = &event {
+            event_type = format!("data_map_insert");
+            Some(serde_json::to_value(data).unwrap())
+        } else {
+            None
+        };
+    let data_map_update_event =
+        if let StacksTransactionEventPayload::DataMapUpdateEvent(data) = &event {
+            event_type = format!("data_map_update");
+            Some(serde_json::to_value(data).unwrap())
+        } else {
+            None
+        };
+    let data_map_delete_event =
+        if let StacksTransactionEventPayload::DataMapDeleteEvent(data) = &event {
+            event_type = format!("data_map_delete");
+            Some(serde_json::to_value(data).unwrap())
+        } else {
+            None
+        };
+    let contract_event = if let StacksTransactionEventPayload::SmartContractEvent(data) = &event {
         event_type = format!("smart_contract_print_event");
         Some(serde_json::to_value(data).unwrap())
     } else {

--- a/components/chainhook-types-rs/src/events.rs
+++ b/components/chainhook-types-rs/src/events.rs
@@ -123,7 +123,7 @@ pub struct SmartContractEventData {
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(tag = "type", content = "data")]
-pub enum StacksTransactionEvent {
+pub enum StacksTransactionEventPayload {
     STXTransferEvent(STXTransferEventData),
     STXMintEvent(STXMintEventData),
     STXLockEvent(STXLockEventData),
@@ -139,4 +139,16 @@ pub enum StacksTransactionEvent {
     DataMapUpdateEvent(DataMapUpdateEventData),
     DataMapDeleteEvent(DataMapDeleteEventData),
     SmartContractEvent(SmartContractEventData),
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct StacksTransactionEvent {
+    #[serde(flatten)]
+    pub event_payload: StacksTransactionEventPayload,
+    pub position: StacksTransactionEventPosition,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct StacksTransactionEventPosition {
+    pub index: u32,
 }

--- a/components/chainhook-types-rs/src/events.rs
+++ b/components/chainhook-types-rs/src/events.rs
@@ -145,10 +145,17 @@ pub enum StacksTransactionEventPayload {
 pub struct StacksTransactionEvent {
     #[serde(flatten)]
     pub event_payload: StacksTransactionEventPayload,
+    #[serde(default)]
     pub position: StacksTransactionEventPosition,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct StacksTransactionEventPosition {
     pub index: u32,
+}
+
+impl Default for StacksTransactionEventPosition {
+    fn default() -> Self {
+        Self { index: 0 }
+    }
 }


### PR DESCRIPTION
(this PR is just cherry-picking the relevant commits from @janniks in PR #417, which I apparently mucked up with some bad merging)

- closes #387 
- adds a position struct to the event and renames the event to payload (with enum type)
- updates occurences.json to include the expected serialized position for testing

---

**Note**: Any users running a Chainhook node (i.e. `chainhook service start ...`) will not have transaction event positions stored in the database, so all event position will have a value of:
``` JSON
"position": {
  "index": 0
}
```
To rebuild the database with this data filled in:
 - Upgrade to the latest version of Chainhook
 - Delete the `stacks.rocksdb` folder inside the `working_dir` set in your `Chainhook.toml`
 - Rerun Chainhook

This will rebuild your Stacks database from scratch. 