### PR TITLE
fix: update scan status for non-triggering predicates

### DIFF
--- a/components/chainhook-cli/src/scan/bitcoin.rs
+++ b/components/chainhook-cli/src/scan/bitcoin.rs
@@ -98,6 +98,20 @@ pub async fn scan_bitcoin_chainstate_via_rpc_using_predicate(
     let http_client = build_http_client();
 
     while let Some(current_block_height) = block_heights_to_scan.pop_front() {
+        if let Some(ref mut predicates_db_conn) = predicates_db_conn {
+            if number_of_blocks_scanned % 10 == 0 || number_of_blocks_scanned == 0 {
+                set_predicate_scanning_status(
+                    &predicate_spec.key(),
+                    number_of_blocks_to_scan,
+                    number_of_blocks_scanned,
+                    number_of_times_triggered,
+                    current_block_height,
+                    predicates_db_conn,
+                    ctx,
+                );
+            }
+        }
+
         if current_block_height > chain_tip {
             let prev_chain_tip = chain_tip;
             // we've scanned up to the chain tip as of the start of this scan
@@ -180,20 +194,6 @@ pub async fn scan_bitcoin_chainstate_via_rpc_using_predicate(
                 ));
             } else {
                 return Err(format!("Scan aborted (consecutive action errors >= 3)"));
-            }
-        }
-
-        if let Some(ref mut predicates_db_conn) = predicates_db_conn {
-            if number_of_blocks_scanned % 10 == 0 || number_of_blocks_scanned == 1 {
-                set_predicate_scanning_status(
-                    &predicate_spec.key(),
-                    number_of_blocks_to_scan,
-                    number_of_blocks_scanned,
-                    number_of_times_triggered,
-                    current_block_height,
-                    predicates_db_conn,
-                    ctx,
-                );
             }
         }
     }


### PR DESCRIPTION
### Description

Previously, we would only update the scanning status every 10 blocks _if_ the block we just scanned had a trigger. This leads to users not getting status updates on the predicates that don't trigger often.

Now, we update status every 10 blocks that we scan. This could lead to some noisy logs, so it should possibly be shipped with #498 


