### PR TITLE
fix: skip db consolidation if no new dataset was downloaded

### DIFF
--- a/components/chainhook-cli/src/scan/stacks.rs
+++ b/components/chainhook-cli/src/scan/stacks.rs
@@ -531,7 +531,7 @@ pub async fn consolidate_local_stacks_chainstate_using_csv(
         let stacks_db_rw = open_readwrite_stacks_db_conn(&config.expected_cache_path(), ctx)?;
         info!(
             ctx.expect_logger(),
-            "Begining import of {} Stacks blocks into rocks db", blocks_to_insert
+            "Beginning import of {} Stacks blocks into rocks db", blocks_to_insert
         );
         for (block_identifier, _parent_block_identifier, blob) in canonical_fork.drain(..) {
             blocks_read += 1;


### PR DESCRIPTION
### Description

The database consolidation loop doesn't need to happen if there is no new data. 

@lgalabru I'm interested in your thoughts on this. Potentially someone could break their stacks.rocksdb, then Chainhook wouldn't automatically fix it unless they deleted their archive to force a redownload, or a new archive becomes available.

I think the tradeoff is worth it because of the improvements to startup time if users are repeatedly running `chainhook predicates scan`, or if the service goes down and needs to restart.

