### PR TITLE
fix: improve error handling, and more!

### DIFF
--- a/components/chainhook-cli/src/archive/tests/mod.rs
+++ b/components/chainhook-cli/src/archive/tests/mod.rs
@@ -72,8 +72,14 @@ async fn it_downloads_stacks_dataset_if_required() {
         tracer: false,
     };
     let mut config_clone = config.clone();
-    assert!(download_stacks_dataset_if_required(&mut config, &ctx).await);
-    assert!(!download_stacks_dataset_if_required(&mut config_clone, &ctx).await);
+    assert!(download_stacks_dataset_if_required(&mut config, &ctx)
+        .await
+        .unwrap());
+    assert!(
+        !download_stacks_dataset_if_required(&mut config_clone, &ctx)
+            .await
+            .unwrap()
+    );
 
     let mut tsv_file_path = config.expected_cache_path();
     tsv_file_path.push(default_tsv_file_path(&config.network.stacks_network));

--- a/components/chainhook-cli/src/cli/mod.rs
+++ b/components/chainhook-cli/src/cli/mod.rs
@@ -277,14 +277,14 @@ pub fn main() {
     let opts: Opts = match Opts::try_parse() {
         Ok(opts) => opts,
         Err(e) => {
-            error!(ctx.expect_logger(), "{e}");
+            crit!(ctx.expect_logger(), "{e}");
             process::exit(1);
         }
     };
 
     match hiro_system_kit::nestable_block_on(handle_command(opts, ctx.clone())) {
         Err(e) => {
-            error!(ctx.expect_logger(), "{e}");
+            crit!(ctx.expect_logger(), "{e}");
             process::exit(1);
         }
         Ok(_) => {}

--- a/components/chainhook-cli/src/config/mod.rs
+++ b/components/chainhook-cli/src/config/mod.rs
@@ -256,13 +256,13 @@ impl Config {
         }
     }
 
-    pub fn expected_local_stacks_tsv_file(&self) -> &PathBuf {
+    pub fn expected_local_stacks_tsv_file(&self) -> Result<&PathBuf, String> {
         for source in self.event_sources.iter() {
             if let EventSourceConfig::StacksTsvPath(config) = source {
-                return &config.file_path;
+                return Ok(&config.file_path);
             }
         }
-        panic!("expected local tsv source")
+        Err(format!("could not find expected local tsv source"))
     }
 
     pub fn expected_cache_path(&self) -> PathBuf {
@@ -271,21 +271,23 @@ impl Config {
         destination_path
     }
 
-    fn expected_remote_stacks_tsv_base_url(&self) -> &String {
+    fn expected_remote_stacks_tsv_base_url(&self) -> Result<&String, String> {
         for source in self.event_sources.iter() {
             if let EventSourceConfig::StacksTsvUrl(config) = source {
-                return &config.file_url;
+                return Ok(&config.file_url);
             }
         }
-        panic!("expected remote tsv source")
+        Err(format!("could not find expected remote tsv source"))
     }
 
-    pub fn expected_remote_stacks_tsv_sha256(&self) -> String {
-        format!("{}.sha256", self.expected_remote_stacks_tsv_base_url())
+    pub fn expected_remote_stacks_tsv_sha256(&self) -> Result<String, String> {
+        self.expected_remote_stacks_tsv_base_url()
+            .map(|url| format!("{}.sha256", url))
     }
 
-    pub fn expected_remote_stacks_tsv_url(&self) -> String {
-        format!("{}.gz", self.expected_remote_stacks_tsv_base_url())
+    pub fn expected_remote_stacks_tsv_url(&self) -> Result<String, String> {
+        self.expected_remote_stacks_tsv_base_url()
+            .map(|url| format!("{}.gz", url))
     }
 
     pub fn rely_on_remote_stacks_tsv(&self) -> bool {

--- a/components/chainhook-cli/src/config/mod.rs
+++ b/components/chainhook-cli/src/config/mod.rs
@@ -262,7 +262,7 @@ impl Config {
                 return &config.file_path;
             }
         }
-        panic!("expected local-tsv source")
+        panic!("expected local tsv source")
     }
 
     pub fn expected_cache_path(&self) -> PathBuf {
@@ -277,7 +277,7 @@ impl Config {
                 return &config.file_url;
             }
         }
-        panic!("expected remote-tsv source")
+        panic!("expected remote tsv source")
     }
 
     pub fn expected_remote_stacks_tsv_sha256(&self) -> String {

--- a/components/chainhook-cli/src/config/mod.rs
+++ b/components/chainhook-cli/src/config/mod.rs
@@ -262,7 +262,7 @@ impl Config {
                 return Ok(&config.file_path);
             }
         }
-        Err(format!("could not find expected local tsv source"))
+        Err("could not find expected local tsv source")?
     }
 
     pub fn expected_cache_path(&self) -> PathBuf {
@@ -277,7 +277,7 @@ impl Config {
                 return Ok(&config.file_url);
             }
         }
-        Err(format!("could not find expected remote tsv source"))
+        Err("could not find expected remote tsv source")?
     }
 
     pub fn expected_remote_stacks_tsv_sha256(&self) -> Result<String, String> {

--- a/components/chainhook-cli/src/config/tests/mod.rs
+++ b/components/chainhook-cli/src/config/tests/mod.rs
@@ -108,7 +108,7 @@ fn should_download_remote_stacks_tsv_handles_both_modes() {
 }
 
 #[test]
-#[should_panic(expected = "expected remote-tsv source")]
+#[should_panic(expected = "expected remote tsv source")]
 fn expected_remote_stacks_tsv_base_url_panics_if_missing() {
     let url_src = EventSourceConfig::StacksTsvUrl(super::UrlConfig {
         file_url: format!("test"),
@@ -123,7 +123,7 @@ fn expected_remote_stacks_tsv_base_url_panics_if_missing() {
 }
 
 #[test]
-#[should_panic(expected = "expected local-tsv source")]
+#[should_panic(expected = "expected local tsv source")]
 fn expected_local_stacks_tsv_base_url_panics_if_missing() {
     let path = PathBuf::from("test");
     let path_src = EventSourceConfig::StacksTsvPath(PathConfig {

--- a/components/chainhook-cli/src/config/tests/mod.rs
+++ b/components/chainhook-cli/src/config/tests/mod.rs
@@ -108,7 +108,6 @@ fn should_download_remote_stacks_tsv_handles_both_modes() {
 }
 
 #[test]
-#[should_panic(expected = "expected remote tsv source")]
 fn expected_remote_stacks_tsv_base_url_panics_if_missing() {
     let url_src = EventSourceConfig::StacksTsvUrl(super::UrlConfig {
         file_url: format!("test"),
@@ -116,15 +115,22 @@ fn expected_remote_stacks_tsv_base_url_panics_if_missing() {
     let mut config = Config::default(true, false, false, &None).unwrap();
 
     config.event_sources = vec![url_src.clone()];
-    assert_eq!(config.expected_remote_stacks_tsv_base_url(), "test");
+    match config.expected_remote_stacks_tsv_base_url() {
+        Ok(tsv_url) => assert_eq!(tsv_url, "test"),
+        Err(e) => {
+            panic!("expected tsv file: {e}")
+        }
+    }
 
     config.event_sources = vec![];
-    config.expected_remote_stacks_tsv_base_url();
+    match config.expected_remote_stacks_tsv_base_url() {
+        Ok(tsv_url) => panic!("expected no tsv file, found {}", tsv_url),
+        Err(e) => assert_eq!(e, "could not find expected remote tsv source".to_string()),
+    };
 }
 
 #[test]
-#[should_panic(expected = "expected local tsv source")]
-fn expected_local_stacks_tsv_base_url_panics_if_missing() {
+fn expected_local_stacks_tsv_base_url_errors_if_missing() {
     let path = PathBuf::from("test");
     let path_src = EventSourceConfig::StacksTsvPath(PathConfig {
         file_path: path.clone(),
@@ -132,10 +138,18 @@ fn expected_local_stacks_tsv_base_url_panics_if_missing() {
     let mut config = Config::default(true, false, false, &None).unwrap();
 
     config.event_sources = vec![path_src.clone()];
-    assert_eq!(config.expected_local_stacks_tsv_file(), &path);
+    match config.expected_local_stacks_tsv_file() {
+        Ok(tsv_path) => assert_eq!(tsv_path, &path),
+        Err(e) => {
+            panic!("expected tsv file: {e}")
+        }
+    }
 
     config.event_sources = vec![];
-    config.expected_local_stacks_tsv_file();
+    match config.expected_local_stacks_tsv_file() {
+        Ok(tsv_path) => panic!("expected no tsv file, found {}", tsv_path.to_string_lossy()),
+        Err(e) => assert_eq!(e, "could not find expected local tsv source".to_string()),
+    };
 }
 
 #[test]

--- a/components/chainhook-cli/src/scan/stacks.rs
+++ b/components/chainhook-cli/src/scan/stacks.rs
@@ -98,7 +98,7 @@ pub async fn get_canonical_fork_from_tsv(
             }
             let _ = record_tx.send(None);
         })
-        .expect("unable to spawn thread");
+        .map_err(|e| format!("unable to spawn thread: {e}"))?;
 
     let stacks_db = open_readonly_stacks_db_conn_with_retry(&config.expected_cache_path(), 3, ctx)?;
     let canonical_fork = {

--- a/components/chainhook-cli/src/scan/stacks.rs
+++ b/components/chainhook-cli/src/scan/stacks.rs
@@ -66,7 +66,7 @@ pub async fn get_canonical_fork_from_tsv(
     start_block: Option<u64>,
     ctx: &Context,
 ) -> Result<VecDeque<(BlockIdentifier, BlockIdentifier, String)>, String> {
-    let seed_tsv_path = config.expected_local_stacks_tsv_file().clone();
+    let seed_tsv_path = config.expected_local_stacks_tsv_file()?.clone();
 
     let (record_tx, record_rx) = std::sync::mpsc::channel();
 
@@ -427,7 +427,7 @@ pub async fn scan_stacks_chainstate_via_csv_using_predicate(
         }
     }
 
-    let _ = download_stacks_dataset_if_required(config, ctx).await;
+    let _ = download_stacks_dataset_if_required(config, ctx).await?;
 
     let mut canonical_fork = get_canonical_fork_from_tsv(config, None, ctx).await?;
 
@@ -523,7 +523,7 @@ pub async fn consolidate_local_stacks_chainstate_using_csv(
         "Building local chainstate from Stacks archive file"
     );
 
-    let downloaded_new_dataset = download_stacks_dataset_if_required(config, ctx).await;
+    let downloaded_new_dataset = download_stacks_dataset_if_required(config, ctx).await?;
 
     if downloaded_new_dataset {
         let stacks_db =

--- a/components/chainhook-cli/src/scan/stacks.rs
+++ b/components/chainhook-cli/src/scan/stacks.rs
@@ -565,8 +565,7 @@ pub async fn consolidate_local_stacks_chainstate_using_csv(
                 }
             };
 
-            // TODO: return a result
-            insert_entry_in_stacks_blocks(&block_data, &stacks_db_rw, ctx);
+            insert_entry_in_stacks_blocks(&block_data, &stacks_db_rw, ctx)?;
 
             if blocks_inserted % 2500 == 0 {
                 info!(

--- a/components/chainhook-cli/src/service/http_api.rs
+++ b/components/chainhook-cli/src/service/http_api.rs
@@ -298,9 +298,12 @@ pub fn get_entry_from_predicates_db(
     let spec = ChainhookSpecification::deserialize_specification(&encoded_spec)?;
 
     let encoded_status = match entry.get("status") {
-        None => unimplemented!(),
-        Some(payload) => payload,
-    };
+        None => Err(format!(
+            "found predicate specification with no status for predicate {}",
+            predicate_key
+        )),
+        Some(payload) => Ok(payload),
+    }?;
 
     let status = serde_json::from_str(&encoded_status).map_err(|e| format!("{}", e.to_string()))?;
 

--- a/components/chainhook-cli/src/service/http_api.rs
+++ b/components/chainhook-cli/src/service/http_api.rs
@@ -28,7 +28,7 @@ pub async fn start_predicate_api_server(
     api_config: PredicatesApiConfig,
     observer_commands_tx: Sender<ObserverCommand>,
     ctx: Context,
-) -> Result<Shutdown, Box<dyn Error>> {
+) -> Result<Shutdown, Box<dyn Error + Send + Sync>> {
     let log_level = LogLevel::Off;
 
     let mut shutdown_config = config::Shutdown::default();
@@ -62,12 +62,12 @@ pub async fn start_predicate_api_server(
         .ignite()
         .await?;
 
-    let ingestion_shutdown = ignite.shutdown();
+    let predicate_api_shutdown = ignite.shutdown();
 
     let _ = std::thread::spawn(move || {
         let _ = hiro_system_kit::nestable_block_on(ignite.launch());
     });
-    Ok(ingestion_shutdown)
+    Ok(predicate_api_shutdown)
 }
 
 #[openapi(tag = "Health Check")]

--- a/components/chainhook-cli/src/service/mod.rs
+++ b/components/chainhook-cli/src/service/mod.rs
@@ -89,15 +89,16 @@ impl Service {
                 }
                 match chainhook_config.register_specification(predicate) {
                     Ok(_) => {
-                        info!(
+                        debug!(
                             self.ctx.expect_logger(),
-                            "Predicate {} retrieved from storage and loaded", predicate_uuid,
+                            "Predicate {} retrieved from storage and registered", predicate_uuid,
                         );
                     }
                     Err(e) => {
-                        error!(
+                        warn!(
                             self.ctx.expect_logger(),
-                            "Failed loading predicate from storage: {}",
+                            "Failed to register predicate {} after retrieving from storage: {}",
+                            predicate_uuid,
                             e.to_string()
                         );
                     }
@@ -117,7 +118,7 @@ impl Service {
                         &self.ctx,
                     ) {
                         Ok(Some(_)) => {
-                            error!(
+                            warn!(
                                 self.ctx.expect_logger(),
                                 "Predicate uuid already in use: {uuid}",
                             );
@@ -136,16 +137,16 @@ impl Service {
             ) {
                 Ok(spec) => {
                     newly_registered_predicates.push(spec.clone());
-                    info!(
+                    debug!(
                         self.ctx.expect_logger(),
                         "Predicate {} retrieved from config and loaded",
                         spec.uuid(),
                     );
                 }
                 Err(e) => {
-                    error!(
+                    warn!(
                         self.ctx.expect_logger(),
-                        "Failed loading predicate from config: {}",
+                        "Failed to load predicate from config: {}",
                         e.to_string()
                     );
                 }
@@ -1190,6 +1191,7 @@ pub fn open_readwrite_predicates_db_conn_verbose(
     res
 }
 
+// todo: evaluate expects
 pub fn open_readwrite_predicates_db_conn_or_panic(
     config: &PredicatesApiConfig,
     ctx: &Context,

--- a/components/chainhook-cli/src/service/mod.rs
+++ b/components/chainhook-cli/src/service/mod.rs
@@ -657,7 +657,7 @@ fn update_status_from_report(
 ) {
     for (predicate_uuid, blocks_ids) in report.predicates_triggered.iter() {
         if let Some(last_triggered_height) = blocks_ids.last().and_then(|b| Some(b.index)) {
-            let triggered_count = blocks_ids.len().try_into().unwrap();
+            let triggered_count = blocks_ids.len().try_into().unwrap_or(0);
             set_predicate_streaming_status(
                 StreamingDataType::Occurrence {
                     last_triggered_height,
@@ -686,7 +686,7 @@ fn update_status_from_report(
             }
         }
         if let Some(last_evaluated_height) = blocks_ids.last().and_then(|b| Some(b.index)) {
-            let evaluated_count = blocks_ids.len().try_into().unwrap();
+            let evaluated_count = blocks_ids.len().try_into().unwrap_or(0);
             set_predicate_streaming_status(
                 StreamingDataType::Evaluation {
                     last_evaluated_height,
@@ -700,7 +700,7 @@ fn update_status_from_report(
     }
     for (predicate_uuid, blocks_ids) in report.predicates_expired.iter() {
         if let Some(last_evaluated_height) = blocks_ids.last().and_then(|b| Some(b.index)) {
-            let evaluated_count = blocks_ids.len().try_into().unwrap();
+            let evaluated_count = blocks_ids.len().try_into().unwrap_or(0);
             set_unconfirmed_expiration_status(
                 &chain,
                 evaluated_count,

--- a/components/chainhook-cli/src/service/mod.rs
+++ b/components/chainhook-cli/src/service/mod.rs
@@ -367,20 +367,20 @@ impl Service {
                         );
                     }
                 }
-                ObserverEvent::PredicateDeregistered(spec) => {
+                ObserverEvent::PredicateDeregistered(uuid) => {
                     if let PredicatesApi::On(ref config) = self.config.http_api {
                         let Ok(mut predicates_db_conn) =
                             open_readwrite_predicates_db_conn_verbose(&config, &ctx)
                         else {
                             continue;
                         };
-                        let predicate_key = spec.key();
+                        let predicate_key = ChainhookSpecification::either_stx_or_btc_key(&uuid);
                         let res: Result<(), redis::RedisError> =
-                            predicates_db_conn.del(predicate_key);
+                            predicates_db_conn.del(predicate_key.clone());
                         if let Err(e) = res {
-                            error!(
+                            warn!(
                                 self.ctx.expect_logger(),
-                                "unable to delete predicate: {}",
+                                "unable to delete predicate {predicate_key}: {}",
                                 e.to_string()
                             );
                         }

--- a/components/chainhook-cli/src/service/mod.rs
+++ b/components/chainhook-cli/src/service/mod.rs
@@ -1069,13 +1069,13 @@ fn insert_predicate_expiration(
     if let Err(e) =
         predicates_db_conn.hset::<_, _, _, ()>(&key, "predicates", &serialized_expiring_predicates)
     {
-        error!(
+        warn!(
             ctx.expect_logger(),
             "Error updating expired predicates index: {}",
             e.to_string()
         );
     } else {
-        info!(
+        debug!(
             ctx.expect_logger(),
             "Updating expired predicates at block height {expired_at_block_height} with predicate: {predicate_key}"
         );
@@ -1094,7 +1094,7 @@ fn get_predicates_expiring_at_block(
             Ok(data) => {
                 if let Err(e) = predicates_db_conn.hdel::<_, _, u64>(key.to_string(), "predicates")
                 {
-                    error!(
+                    warn!(
                         ctx.expect_logger(),
                         "Error removing expired predicates index: {}",
                         e.to_string()
@@ -1118,13 +1118,14 @@ pub fn update_predicate_status(
     if let Err(e) =
         predicates_db_conn.hset::<_, _, _, ()>(&predicate_key, "status", &serialized_status)
     {
-        error!(
+        warn!(
             ctx.expect_logger(),
-            "Error updating status: {}",
+            "Error updating status for {}: {}",
+            predicate_key,
             e.to_string()
         );
     } else {
-        info!(
+        debug!(
             ctx.expect_logger(),
             "Updating predicate {predicate_key} status: {serialized_status}"
         );
@@ -1141,13 +1142,14 @@ fn update_predicate_spec(
     if let Err(e) =
         predicates_db_conn.hset::<_, _, _, ()>(&predicate_key, "specification", &serialized_spec)
     {
-        error!(
+        warn!(
             ctx.expect_logger(),
-            "Error updating status: {}",
+            "Error updating status for {}: {}",
+            predicate_key,
             e.to_string()
         );
     } else {
-        info!(
+        debug!(
             ctx.expect_logger(),
             "Updating predicate {predicate_key} with spec: {serialized_spec}"
         );

--- a/components/chainhook-cli/src/service/mod.rs
+++ b/components/chainhook-cli/src/service/mod.rs
@@ -176,9 +176,12 @@ impl Service {
                 start_stacks_scan_runloop(
                     &config,
                     stacks_scan_op_rx,
-                    observer_command_tx_moved,
+                    observer_command_tx_moved.clone(),
                     &ctx,
                 );
+                // the scan runloop should loop forever; if it finishes, something is wrong
+                crit!(ctx.expect_logger(), "Stacks scan runloop stopped.",);
+                let _ = observer_command_tx_moved.send(ObserverCommand::Terminate);
             })
             .expect("unable to spawn thread");
 
@@ -192,9 +195,12 @@ impl Service {
                 start_bitcoin_scan_runloop(
                     &config,
                     bitcoin_scan_op_rx,
-                    observer_command_tx_moved,
+                    observer_command_tx_moved.clone(),
                     &ctx,
                 );
+                // the scan runloop should loop forever; if it finishes, something is wrong
+                crit!(ctx.expect_logger(), "Bitcoin scan runloop stopped.",);
+                let _ = observer_command_tx_moved.send(ObserverCommand::Terminate);
             })
             .expect("unable to spawn thread");
 

--- a/components/chainhook-cli/src/service/mod.rs
+++ b/components/chainhook-cli/src/service/mod.rs
@@ -602,20 +602,22 @@ impl Service {
                     // Every 32 blocks, we will check if there's a new Stacks file archive to ingest
                     if stacks_event > 32 {
                         stacks_event = 0;
-                        match consolidate_local_stacks_chainstate_using_csv(
-                            &mut self.config,
-                            &self.ctx,
-                        )
-                        .await
-                        {
-                            Err(e) => {
-                                error!(
-                                    self.ctx.expect_logger(),
-                                    "Failed to update database from archive: {e}"
-                                )
-                            }
-                            Ok(()) => {}
-                        };
+                        if self.config.rely_on_remote_stacks_tsv() {
+                            match consolidate_local_stacks_chainstate_using_csv(
+                                &mut self.config,
+                                &self.ctx,
+                            )
+                            .await
+                            {
+                                Err(e) => {
+                                    error!(
+                                        self.ctx.expect_logger(),
+                                        "Failed to update database from archive: {e}"
+                                    )
+                                }
+                                Ok(()) => {}
+                            };
+                        }
                     }
                 }
                 ObserverEvent::Terminate => {

--- a/components/chainhook-cli/src/service/mod.rs
+++ b/components/chainhook-cli/src/service/mod.rs
@@ -480,28 +480,48 @@ impl Service {
 
                     match &chain_event {
                         StacksChainEvent::ChainUpdatedWithBlocks(data) => {
-                            confirm_entries_in_stacks_blocks(
+                            if let Err(e) = confirm_entries_in_stacks_blocks(
                                 &data.confirmed_blocks,
                                 &stacks_db_conn_rw,
                                 &self.ctx,
-                            );
-                            draft_entries_in_stacks_blocks(
+                            ) {
+                                error!(
+                                    self.ctx.expect_logger(),
+                                    "unable add confirmed entries to stacks db: {}", e
+                                );
+                            };
+                            if let Err(e) = draft_entries_in_stacks_blocks(
                                 &data.new_blocks,
                                 &stacks_db_conn_rw,
                                 &self.ctx,
-                            )
+                            ) {
+                                error!(
+                                    self.ctx.expect_logger(),
+                                    "unable add unconfirmed entries to stacks db: {}", e
+                                );
+                            };
                         }
                         StacksChainEvent::ChainUpdatedWithReorg(data) => {
-                            confirm_entries_in_stacks_blocks(
+                            if let Err(e) = confirm_entries_in_stacks_blocks(
                                 &data.confirmed_blocks,
                                 &stacks_db_conn_rw,
                                 &self.ctx,
-                            );
-                            draft_entries_in_stacks_blocks(
+                            ) {
+                                error!(
+                                    self.ctx.expect_logger(),
+                                    "unable add confirmed entries to stacks db: {}", e
+                                );
+                            };
+                            if let Err(e) = draft_entries_in_stacks_blocks(
                                 &data.blocks_to_apply,
                                 &stacks_db_conn_rw,
                                 &self.ctx,
-                            )
+                            ) {
+                                error!(
+                                    self.ctx.expect_logger(),
+                                    "unable add unconfirmed entries to stacks db: {}", e
+                                );
+                            };
                         }
                         StacksChainEvent::ChainUpdatedWithMicroblocks(_)
                         | StacksChainEvent::ChainUpdatedWithMicroblocksReorg(_) => {}

--- a/components/chainhook-cli/src/service/mod.rs
+++ b/components/chainhook-cli/src/service/mod.rs
@@ -281,7 +281,7 @@ impl Service {
             let event = match observer_event_rx.recv() {
                 Ok(cmd) => cmd,
                 Err(e) => {
-                    error!(
+                    crit!(
                         self.ctx.expect_logger(),
                         "Error: broken channel {}",
                         e.to_string()

--- a/components/chainhook-cli/src/service/mod.rs
+++ b/components/chainhook-cli/src/service/mod.rs
@@ -429,7 +429,7 @@ impl Service {
                                 }
                             }
                         }
-                        update_stats_from_report(
+                        update_status_from_report(
                             Chain::Bitcoin,
                             report,
                             &mut predicates_db_conn,
@@ -546,7 +546,7 @@ impl Service {
                             StacksChainEvent::ChainUpdatedWithMicroblocks(_)
                             | StacksChainEvent::ChainUpdatedWithMicroblocksReorg(_) => {}
                         };
-                        update_stats_from_report(
+                        update_status_from_report(
                             Chain::Stacks,
                             report,
                             &mut predicates_db_conn,
@@ -615,7 +615,7 @@ pub struct ExpiredData {
     pub expired_at_block_height: u64,
 }
 
-fn update_stats_from_report(
+fn update_status_from_report(
     chain: Chain,
     report: PredicateEvaluationReport,
     predicates_db_conn: &mut Connection,

--- a/components/chainhook-cli/src/service/mod.rs
+++ b/components/chainhook-cli/src/service/mod.rs
@@ -452,7 +452,7 @@ impl Service {
                         Err(e) => {
                             error!(
                                 self.ctx.expect_logger(),
-                                "unable to store stacks block: {}",
+                                "unable to open stacks db: {}",
                                 e.to_string()
                             );
                             continue;

--- a/components/chainhook-cli/src/service/runloops.rs
+++ b/components/chainhook-cli/src/service/runloops.rs
@@ -43,9 +43,12 @@ pub fn start_stacks_scan_runloop(
                 {
                     Ok(db_conn) => db_conn,
                     Err(e) => {
+                        // todo: if we repeatedly can't connect to the database, we should restart the
+                        // service to get to a healthy state. I don't know if this has been an issue, though
+                        // so we can monitor and possibly remove this todo
                         error!(
                             moved_ctx.expect_logger(),
-                            "unable to store stacks block: {}",
+                            "unable to open stacks db: {}",
                             e.to_string()
                         );
                         unimplemented!()
@@ -108,8 +111,7 @@ pub fn start_stacks_scan_runloop(
             }
         });
     }
-    let res = stacks_scan_pool.join();
-    res
+    let _ = stacks_scan_pool.join();
 }
 
 pub fn start_bitcoin_scan_runloop(

--- a/components/chainhook-cli/src/service/runloops.rs
+++ b/components/chainhook-cli/src/service/runloops.rs
@@ -140,7 +140,7 @@ pub fn start_bitcoin_scan_runloop(
             let predicate_is_expired = match hiro_system_kit::nestable_block_on(op) {
                 Ok(predicate_is_expired) => predicate_is_expired,
                 Err(e) => {
-                    error!(
+                    warn!(
                         moved_ctx.expect_logger(),
                         "Unable to evaluate predicate on Bitcoin chainstate: {e}",
                     );

--- a/components/chainhook-sdk/Cargo.toml
+++ b/components/chainhook-sdk/Cargo.toml
@@ -50,4 +50,4 @@ test-case = "3.1.0"
 default = ["hiro-system-kit/log"]
 zeromq = ["zmq"]
 debug = ["hiro-system-kit/debug"]
-release = ["hiro-system-kit/release"]
+release = ["hiro-system-kit/debug"]

--- a/components/chainhook-sdk/src/indexer/fork_scratch_pad.rs
+++ b/components/chainhook-sdk/src/indexer/fork_scratch_pad.rs
@@ -293,7 +293,7 @@ impl ForkScratchPad {
                         ctx.try_log(|logger| {
                             slog::error!(
                                 logger,
-                                "unable to retrive Bitcoin {} from block store",
+                                "unable to retrieve Bitcoin block {} from block store",
                                 block_identifier
                             )
                         });

--- a/components/chainhook-sdk/src/indexer/mod.rs
+++ b/components/chainhook-sdk/src/indexer/mod.rs
@@ -367,7 +367,7 @@ impl ChainSegment {
             }
             Err(incompatibility) => {
                 ctx.try_log(|logger| {
-                    slog::info!(logger, "Will have to fork: {:?}", incompatibility)
+                    slog::warn!(logger, "Will have to fork: {:?}", incompatibility)
                 });
                 match incompatibility {
                     ChainSegmentIncompatibility::BlockCollision => {

--- a/components/chainhook-sdk/src/indexer/stacks/mod.rs
+++ b/components/chainhook-sdk/src/indexer/stacks/mod.rs
@@ -290,9 +290,11 @@ pub fn standardize_stacks_serialized_block_header(
         .parent_index_block_hash
         .take()
         .ok_or(format!("unable to retrieve parent_index_block_hash"))?;
+
+    let parent_height = block_identifier.index.saturating_sub(1);
     let parent_block_identifier = BlockIdentifier {
         hash: parent_hash,
-        index: block_identifier.index - 1,
+        index: parent_height,
     };
     Ok((block_identifier, parent_block_identifier))
 }
@@ -902,7 +904,7 @@ pub fn get_standardized_non_fungible_currency_from_asset_class_id(
         }),
     }
 }
-
+//todo: this function has a lot of expects/panics. should return result instead
 pub fn get_standardized_stacks_receipt(
     _txid: &str,
     events: Vec<StacksTransactionEvent>,

--- a/components/chainhook-sdk/src/observer/http.rs
+++ b/components/chainhook-sdk/src/observer/http.rs
@@ -132,7 +132,7 @@ pub async fn handle_new_bitcoin_block(
             };
         }
         Ok(None) => {
-            ctx.try_log(|logger| slog::info!(logger, "unable to infer chain progress"));
+            ctx.try_log(|logger| slog::warn!(logger, "unable to infer chain progress"));
         }
         Err(e) => {
             ctx.try_log(|logger| slog::error!(logger, "unable to handle bitcoin block: {}", e))
@@ -202,7 +202,7 @@ pub fn handle_new_stacks_block(
             };
         }
         Ok(None) => {
-            ctx.try_log(|logger| slog::info!(logger, "unable to infer chain progress"));
+            ctx.try_log(|logger| slog::warn!(logger, "unable to infer chain progress"));
         }
         Err(e) => ctx.try_log(|logger| slog::error!(logger, "{}", e)),
     }
@@ -273,7 +273,7 @@ pub fn handle_new_microblocks(
             };
         }
         Ok(None) => {
-            ctx.try_log(|logger| slog::info!(logger, "unable to infer chain progress"));
+            ctx.try_log(|logger| slog::warn!(logger, "unable to infer chain progress"));
         }
         Err(e) => {
             ctx.try_log(|logger| slog::error!(logger, "unable to handle stacks microblock: {}", e));

--- a/components/chainhook-sdk/src/observer/mod.rs
+++ b/components/chainhook-sdk/src/observer/mod.rs
@@ -1181,6 +1181,7 @@ pub async fn start_observer_commands_handler(
                 }
 
                 for (request, data) in requests.into_iter() {
+                    // todo: need to handle failure case - we should be setting interrupted status: https://github.com/hirosystems/chainhook/issues/523
                     if send_request(request, 3, 1, &ctx).await.is_ok() {
                         if let Some(ref tx) = observer_events_tx {
                             let _ = tx.send(ObserverEvent::BitcoinPredicateTriggered(data));

--- a/components/chainhook-sdk/src/observer/mod.rs
+++ b/components/chainhook-sdk/src/observer/mod.rs
@@ -1349,8 +1349,7 @@ pub async fn start_observer_commands_handler(
                                 e.to_string()
                             )
                         });
-                        panic!("Unable to register new chainhook spec: {}", e.to_string());
-                        //continue;
+                        continue;
                     }
                 };
 

--- a/components/chainhook-sdk/src/observer/tests/mod.rs
+++ b/components/chainhook-sdk/src/observer/tests/mod.rs
@@ -498,10 +498,7 @@ fn test_stacks_chainhook_register_deregister() {
     ));
     assert!(match observer_events_rx.recv() {
         Ok(ObserverEvent::PredicateDeregistered(deregistered_chainhook)) => {
-            assert_eq!(
-                ChainhookSpecification::Stacks(chainhook),
-                deregistered_chainhook
-            );
+            assert_eq!(chainhook.uuid, deregistered_chainhook);
             true
         }
         _ => false,
@@ -692,7 +689,7 @@ fn test_stacks_chainhook_auto_deregister() {
     // Should signal that a hook was deregistered
     assert!(match observer_events_rx.recv() {
         Ok(ObserverEvent::PredicateDeregistered(deregistered_hook)) => {
-            assert_eq!(deregistered_hook.uuid(), chainhook.uuid);
+            assert_eq!(deregistered_hook, chainhook.uuid);
             true
         }
         _ => false,
@@ -858,10 +855,7 @@ fn test_bitcoin_chainhook_register_deregister() {
     ));
     assert!(match observer_events_rx.recv() {
         Ok(ObserverEvent::PredicateDeregistered(deregistered_chainhook)) => {
-            assert_eq!(
-                ChainhookSpecification::Bitcoin(chainhook),
-                deregistered_chainhook
-            );
+            assert_eq!(chainhook.uuid, deregistered_chainhook);
             true
         }
         _ => false,
@@ -1069,7 +1063,7 @@ fn test_bitcoin_chainhook_auto_deregister() {
     // Should signal that a hook was deregistered
     assert!(match observer_events_rx.recv() {
         Ok(ObserverEvent::PredicateDeregistered(deregistered_hook)) => {
-            assert_eq!(deregistered_hook.uuid(), chainhook.uuid);
+            assert_eq!(deregistered_hook, chainhook.uuid);
             true
         }
         _ => false,

--- a/components/chainhook-sdk/src/utils/mod.rs
+++ b/components/chainhook-sdk/src/utils/mod.rs
@@ -164,7 +164,7 @@ pub async fn send_request(
         let err_msg = match request_builder.send().await {
             Ok(res) => {
                 if res.status().is_success() {
-                    ctx.try_log(|logger| slog::info!(logger, "Trigger {} successful", res.url()));
+                    ctx.try_log(|logger| slog::debug!(logger, "Trigger {} successful", res.url()));
                     return Ok(());
                 } else {
                     retry += 1;


### PR DESCRIPTION
This PR introduces a few fixes in an effort to improve reliability and debugging problems when running Chainhook as a service:
 - Revisits log levels throughout the tool (fixes #498, fixes #521). The general approach for the logs were:
   - `crit` - fatal errors that will crash mission critical component of Chainhook. In these cases, Chainhook should automatically kill all main threads (not individual scanning threads, which is tracked by #404) to crash the service.
   - `erro` - something went wrong the could lead to a critical error, or that could impact all users
   - `warn` - something went wrong that could impact an end user (usually due to user error)
   - `info` - control flow logging and updates on the state of _all_ registered predicates
   - `debug` - updates on the state of _a_ predicate
 - Crash the service if a mission critical thread fails (see https://github.com/hirosystems/chainhook/issues/517#issuecomment-1992135101 for a list of these threads). Previously, if one of these threads failed, the remaining services would keep running. For example, if the event observer handler crashed, the event observer API would keep running. This means that the stacks node is successfully emitting blocks that Chainhook is acknowledging but not ingesting. This causes gaps in our database Fixes #517
 - Removes an infinite loop with bitcoin ingestion, crashing the service instead: Fixes #506 
 - Fixes how we delete predicates from our db when one is deregistered. This should reduce the number of logs we have on startup. Fixes #510 
 - Warns on all reorgs. Fixes #519 
 


