### PR TITLE
chore: use stacks-codec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3696,6 +3696,7 @@ dependencies = [
 [[package]]
 name = "stacks-codec"
 version = "2.4.1"
+source = "git+https://github.com/hirosystems/clarinet.git?branch=feat/stacks-codec#a9da55627efdbc5c72e468dfb2d5ab39d0be2c60"
 dependencies = [
  "clarity",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3696,6 +3696,7 @@ dependencies = [
 [[package]]
 name = "stacks-codec"
 version = "2.4.1"
+source = "git+https://github.com/hirosystems/clarinet.git?branch=feat/stacks-codec#b39261ae29babfab3c77395483c5a11178d849ca"
 dependencies = [
  "clarity",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3696,7 +3696,7 @@ dependencies = [
 [[package]]
 name = "stacks-codec"
 version = "2.4.1"
-source = "git+https://github.com/hirosystems/clarinet.git?branch=feat/stacks-codec#a9da55627efdbc5c72e468dfb2d5ab39d0be2c60"
+source = "git+https://github.com/hirosystems/clarinet.git?branch=feat/stacks-codec#f8bd0af8e387c3c5169a261f3257380397a8c0fb"
 dependencies = [
  "clarity",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ dependencies = [
  "cipher",
  "ctr",
  "ghash",
- "subtle 2.5.0",
+ "subtle",
 ]
 
 [[package]]
@@ -129,12 +129,6 @@ checksum = "23589ecb866b460d3a0f1278834750268c607e8e28a1b982c907219f3178cd72"
 dependencies = [
  "nodrop",
 ]
-
-[[package]]
-name = "arrayref"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
 
 [[package]]
 name = "arrayvec"
@@ -221,12 +215,6 @@ dependencies = [
  "object",
  "rustc-demangle",
 ]
-
-[[package]]
-name = "base58"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5024ee8015f02155eee35c711107ddd9a9bf3cb689cf2a9089c97e79b6e1ae83"
 
 [[package]]
 name = "base58"
@@ -378,41 +366,11 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
-dependencies = [
- "block-padding",
- "byte-tools",
- "byteorder",
- "generic-array 0.12.4",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array 0.14.7",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array 0.14.7",
-]
-
-[[package]]
-name = "block-padding"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
-dependencies = [
- "byte-tools",
 ]
 
 [[package]]
@@ -441,12 +399,6 @@ name = "byte-slice-cast"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
-
-[[package]]
-name = "byte-tools"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "bytemuck"
@@ -535,9 +487,9 @@ dependencies = [
  "flume",
  "futures-util",
  "hex",
- "hiro-system-kit 0.3.4",
+ "hiro-system-kit",
  "num_cpus",
- "rand 0.8.5",
+ "rand",
  "redis",
  "reqwest",
  "rocket",
@@ -560,7 +512,7 @@ dependencies = [
 name = "chainhook-sdk"
 version = "0.12.5"
 dependencies = [
- "base58 0.2.0",
+ "base58",
  "base64 0.21.5",
  "bitcoincore-rpc",
  "bitcoincore-rpc-json",
@@ -570,12 +522,12 @@ dependencies = [
  "futures",
  "fxhash",
  "hex",
- "hiro-system-kit 0.3.4",
+ "hiro-system-kit",
  "hyper",
  "lazy_static",
  "miniscript",
  "prometheus",
- "rand 0.8.5",
+ "rand",
  "regex",
  "reqwest",
  "rocket",
@@ -584,7 +536,7 @@ dependencies = [
  "serde-hex",
  "serde_derive",
  "serde_json",
- "stacks-rpc-client",
+ "stacks-codec",
  "test-case",
  "threadpool",
  "tokio",
@@ -715,8 +667,8 @@ dependencies = [
  "hashbrown 0.14.3",
  "integer-sqrt",
  "lazy_static",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
+ "rand",
+ "rand_chacha",
  "regex",
  "rusqlite",
  "serde",
@@ -727,29 +679,6 @@ dependencies = [
  "slog",
  "stacks-common",
  "wasmtime",
-]
-
-[[package]]
-name = "clarity-repl"
-version = "2.4.1"
-source = "git+https://github.com/hirosystems/clarinet.git#175103ecfbeb9d592640650d25947eeb3a7e3196"
-dependencies = [
- "ansi_term",
- "atty",
- "chrono",
- "clarity",
- "getrandom 0.2.11",
- "hiro-system-kit 0.1.0",
- "integer-sqrt",
- "lazy_static",
- "pox-locking",
- "regex",
- "reqwest",
- "serde",
- "serde_derive",
- "serde_json",
- "sha2 0.10.8",
- "wsts",
 ]
 
 [[package]]
@@ -1050,26 +979,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-mac"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
-dependencies = [
- "generic-array 0.12.4",
- "subtle 1.0.0",
-]
-
-[[package]]
-name = "crypto-mac"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
-dependencies = [
- "generic-array 0.14.7",
- "subtle 2.5.0",
-]
-
-[[package]]
 name = "csv"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1119,7 +1028,7 @@ dependencies = [
  "digest 0.8.1",
  "rand_core 0.5.1",
  "serde",
- "subtle 2.5.0",
+ "subtle",
  "zeroize",
 ]
 
@@ -1136,7 +1045,7 @@ dependencies = [
  "fiat-crypto",
  "platforms",
  "rustc_version",
- "subtle 2.5.0",
+ "subtle",
  "zeroize",
 ]
 
@@ -1271,22 +1180,12 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array 0.14.7",
-]
-
-[[package]]
-name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
+ "block-buffer",
  "crypto-common",
- "subtle 2.5.0",
 ]
 
 [[package]]
@@ -1358,8 +1257,8 @@ dependencies = [
  "ed25519",
  "rand_core 0.6.4",
  "serde",
- "sha2 0.10.8",
- "subtle 2.5.0",
+ "sha2",
+ "subtle",
  "zeroize",
 ]
 
@@ -1393,12 +1292,6 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "fake-simd"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "fallible-iterator"
@@ -1463,7 +1356,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand 0.8.5",
+ "rand",
  "rustc-hex",
  "static_assertions",
 ]
@@ -1685,7 +1578,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
 dependencies = [
- "opaque-debug 0.3.0",
+ "opaque-debug",
  "polyval",
 ]
 
@@ -1816,17 +1709,6 @@ checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
 
 [[package]]
 name = "hiro-system-kit"
-version = "0.1.0"
-source = "git+https://github.com/hirosystems/clarinet.git#175103ecfbeb9d592640650d25947eeb3a7e3196"
-dependencies = [
- "ansi_term",
- "atty",
- "lazy_static",
- "tokio",
-]
-
-[[package]]
-name = "hiro-system-kit"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3bf5cf007a9973ef9b7dffe8d63fa5228e9bb1aa012e89da2b9f1e7119ce6e"
@@ -1842,57 +1724,6 @@ dependencies = [
  "slog-term",
  "time",
  "tokio",
-]
-
-[[package]]
-name = "hmac"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
-dependencies = [
- "crypto-mac 0.7.0",
- "digest 0.8.1",
-]
-
-[[package]]
-name = "hmac"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
-dependencies = [
- "crypto-mac 0.8.0",
- "digest 0.9.0",
-]
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest 0.10.7",
-]
-
-[[package]]
-name = "hmac-drbg"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e570451493f10f6581b48cdd530413b63ea9e780f544bfd3bdcaa0d89d1a7b"
-dependencies = [
- "digest 0.8.1",
- "generic-array 0.12.4",
- "hmac 0.7.1",
-]
-
-[[package]]
-name = "hmac-drbg"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
-dependencies = [
- "digest 0.9.0",
- "generic-array 0.14.7",
- "hmac 0.8.1",
 ]
 
 [[package]]
@@ -2248,70 +2079,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libsecp256k1"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc1e2c808481a63dc6da2074752fdd4336a3c8fcc68b83db6f1fd5224ae7962"
-dependencies = [
- "arrayref",
- "crunchy",
- "digest 0.8.1",
- "hmac-drbg 0.2.0",
- "rand 0.7.3",
- "sha2 0.8.2",
- "subtle 2.5.0",
- "typenum",
-]
-
-[[package]]
-name = "libsecp256k1"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95b09eff1b35ed3b33b877ced3a691fc7a481919c7e29c53c906226fcf55e2a1"
-dependencies = [
- "arrayref",
- "base64 0.13.1",
- "digest 0.9.0",
- "hmac-drbg 0.3.0",
- "libsecp256k1-core",
- "libsecp256k1-gen-ecmult",
- "libsecp256k1-gen-genmult",
- "rand 0.8.5",
- "serde",
- "sha2 0.9.9",
- "typenum",
-]
-
-[[package]]
-name = "libsecp256k1-core"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be9b9bb642d8522a44d533eab56c16c738301965504753b03ad1de3425d5451"
-dependencies = [
- "crunchy",
- "digest 0.9.0",
- "subtle 2.5.0",
-]
-
-[[package]]
-name = "libsecp256k1-gen-ecmult"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3038c808c55c87e8a172643a7d87187fc6c4174468159cb3090659d55bcb4809"
-dependencies = [
- "libsecp256k1-core",
-]
-
-[[package]]
-name = "libsecp256k1-gen-genmult"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db8d6ba2cec9eacc40e6e8ccc98931840301f1006e95647ceb2dd5c3aa06f7c"
-dependencies = [
- "libsecp256k1-core",
-]
-
-[[package]]
 name = "libsqlite3-sys"
 version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2436,12 +2203,6 @@ checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
-
-[[package]]
-name = "memzero"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93c0d11ac30a033511ae414355d80f70d9f29a44a49140face477117a1ee90db"
 
 [[package]]
 name = "mime"
@@ -2636,12 +2397,6 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opaque-debug"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
-
-[[package]]
-name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
@@ -2676,7 +2431,7 @@ dependencies = [
  "rand_core 0.6.4",
  "rustfmt-wrapper",
  "serde",
- "sha2 0.10.8",
+ "sha2",
  "syn 2.0.43",
 ]
 
@@ -2730,33 +2485,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "password-hash"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
-dependencies = [
- "base64ct",
- "rand_core 0.6.4",
- "subtle 2.5.0",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
-
-[[package]]
-name = "pbkdf2"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
-dependencies = [
- "digest 0.10.7",
- "hmac 0.12.1",
- "password-hash",
- "sha2 0.10.8",
-]
 
 [[package]]
 name = "pear"
@@ -2893,7 +2625,7 @@ checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "opaque-debug 0.3.0",
+ "opaque-debug",
  "universal-hash",
 ]
 
@@ -2902,16 +2634,6 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
-
-[[package]]
-name = "pox-locking"
-version = "2.4.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-next#35cce11f4a7e49f29dd1cf06680abfbd31099669"
-dependencies = [
- "clarity",
- "slog",
- "stacks-common",
-]
 
 [[package]]
 name = "ppv-lite86"
@@ -3032,36 +2754,13 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -3090,15 +2789,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.11",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -3320,7 +3010,7 @@ dependencies = [
  "num_cpus",
  "parking_lot",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand",
  "ref-cast",
  "rocket_codegen",
  "rocket_http",
@@ -3600,7 +3290,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acea373acb8c21ecb5a23741452acd2593ed44ee3d343e72baaa143bc89d0d5"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.8.5",
+ "rand",
  "secp256k1-sys 0.9.1",
  "serde",
 ]
@@ -3772,31 +3462,6 @@ name = "sha1_smol"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
-
-[[package]]
-name = "sha2"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
-dependencies = [
- "block-buffer 0.7.3",
- "digest 0.8.1",
- "fake-simd",
- "opaque-debug 0.2.3",
-]
-
-[[package]]
-name = "sha2"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug 0.3.0",
-]
 
 [[package]]
 name = "sha2"
@@ -4029,6 +3694,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "stacks-codec"
+version = "2.4.1"
+dependencies = [
+ "clarity",
+ "serde",
+ "serde_json",
+ "wsts",
+]
+
+[[package]]
 name = "stacks-common"
 version = "0.0.2"
 source = "git+https://github.com/stacks-network/stacks-core.git?branch=feat/clarity-wasm-next#35cce11f4a7e49f29dd1cf06680abfbd31099669"
@@ -4041,14 +3716,14 @@ dependencies = [
  "libc",
  "nix 0.23.2",
  "percent-encoding",
- "rand 0.8.5",
+ "rand",
  "ripemd",
  "rusqlite",
  "secp256k1 0.24.3",
  "serde",
  "serde_derive",
  "serde_json",
- "sha2 0.10.8",
+ "sha2",
  "sha3",
  "slog",
  "slog-json",
@@ -4056,23 +3731,6 @@ dependencies = [
  "time",
  "winapi",
  "wsts",
-]
-
-[[package]]
-name = "stacks-rpc-client"
-version = "2.4.1"
-source = "git+https://github.com/hirosystems/clarinet.git#175103ecfbeb9d592640650d25947eeb3a7e3196"
-dependencies = [
- "clarity-repl",
- "hmac 0.12.1",
- "libsecp256k1 0.7.1",
- "pbkdf2",
- "reqwest",
- "serde",
- "serde_derive",
- "serde_json",
- "sha2 0.10.8",
- "tiny-hderive",
 ]
 
 [[package]]
@@ -4117,12 +3775,6 @@ dependencies = [
  "rustversion",
  "syn 1.0.109",
 ]
-
-[[package]]
-name = "subtle"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 
 [[package]]
 name = "subtle"
@@ -4366,19 +4018,6 @@ checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
 dependencies = [
  "num-conv",
  "time-core",
-]
-
-[[package]]
-name = "tiny-hderive"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b874a4992538d4b2f4fbbac11b9419d685f4b39bdc3fed95b04e07bfd76040"
-dependencies = [
- "base58 0.1.0",
- "hmac 0.7.1",
- "libsecp256k1 0.3.5",
- "memzero",
- "sha2 0.8.2",
 ]
 
 [[package]]
@@ -4695,7 +4334,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
  "crypto-common",
- "subtle 2.5.0",
+ "subtle",
 ]
 
 [[package]]
@@ -4722,7 +4361,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
 dependencies = [
  "getrandom 0.2.11",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -4947,7 +4586,7 @@ dependencies = [
  "rustix",
  "serde",
  "serde_derive",
- "sha2 0.10.8",
+ "sha2",
  "toml 0.5.11",
  "windows-sys 0.48.0",
  "zstd",
@@ -5116,7 +4755,7 @@ dependencies = [
  "memfd",
  "memoffset 0.9.1",
  "paste",
- "rand 0.8.5",
+ "rand",
  "rustix",
  "sptr",
  "wasm-encoder 0.36.2",
@@ -5442,7 +5081,7 @@ dependencies = [
  "primitive-types",
  "rand_core 0.6.4",
  "serde",
- "sha2 0.10.8",
+ "sha2",
  "thiserror",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3696,7 +3696,6 @@ dependencies = [
 [[package]]
 name = "stacks-codec"
 version = "2.4.1"
-source = "git+https://github.com/hirosystems/clarinet.git?branch=feat/stacks-codec#b39261ae29babfab3c77395483c5a11178d849ca"
 dependencies = [
  "clarity",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3699,7 +3699,6 @@ version = "2.4.1"
 dependencies = [
  "clarity",
  "serde",
- "serde_json",
  "wsts",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 default-members = ["components/chainhook-cli", "components/chainhook-sdk"]
 resolver = "2"
 
-[replace]
-"jsonrpc:0.13.0" = { git = 'https://github.com/apoelstra/rust-jsonrpc', rev = "1063671f122a8985c1b7c29030071253da515839" }
+# [patch.'https://github.com/hirosystems/clarinet.git']
+# stacks-codec = { path = "../clarinet/components/stacks-codec" }

--- a/components/chainhook-sdk/Cargo.toml
+++ b/components/chainhook-sdk/Cargo.toml
@@ -12,8 +12,8 @@ serde = { version = "1", features = ["rc"] }
 serde_json = { version = "1", features = ["arbitrary_precision"] }
 serde-hex = "0.1.0"
 serde_derive = "1"
-# stacks-codec = { git = "https://github.com/hirosystems/clarinet.git", branch = "feat/handle-epoch3_0" }
-stacks-codec = { path = "../../../clarinet/components/stacks-codec" }
+stacks-codec = { git = "https://github.com/hirosystems/clarinet.git", branch = "feat/stacks-codec" }
+# stacks-codec = { path = "../../../clarinet/components/stacks-codec" }
 # hiro-system-kit = { version = "0.1.0", path = "../../../clarinet/components/hiro-system-kit" }
 hiro-system-kit = { version = "0.3.1", optional = true }
 chainhook-types = { version = "1.3.3", path = "../chainhook-types-rs" }

--- a/components/chainhook-sdk/Cargo.toml
+++ b/components/chainhook-sdk/Cargo.toml
@@ -13,7 +13,7 @@ serde_json = { version = "1", features = ["arbitrary_precision"] }
 serde-hex = "0.1.0"
 serde_derive = "1"
 # stacks-codec = { git = "https://github.com/hirosystems/clarinet.git", branch = "feat/handle-epoch3_0" }
-stacks-codec = { version = "2", path = "../../../clarinet/components/stacks-codec" }
+stacks-codec = { path = "../../../clarinet/components/stacks-codec" }
 # hiro-system-kit = { version = "0.1.0", path = "../../../clarinet/components/hiro-system-kit" }
 hiro-system-kit = { version = "0.3.1", optional = true }
 chainhook-types = { version = "1.3.3", path = "../chainhook-types-rs" }

--- a/components/chainhook-sdk/Cargo.toml
+++ b/components/chainhook-sdk/Cargo.toml
@@ -12,8 +12,8 @@ serde = { version = "1", features = ["rc"] }
 serde_json = { version = "1", features = ["arbitrary_precision"] }
 serde-hex = "0.1.0"
 serde_derive = "1"
-stacks-codec = { git = "https://github.com/hirosystems/clarinet.git", branch = "feat/stacks-codec" }
-# stacks-codec = { path = "../../../clarinet/components/stacks-codec" }
+# stacks-codec = { git = "https://github.com/hirosystems/clarinet.git", branch = "feat/stacks-codec" }
+stacks-codec = { path = "../../../clarinet/components/stacks-codec" }
 # hiro-system-kit = { version = "0.1.0", path = "../../../clarinet/components/hiro-system-kit" }
 hiro-system-kit = { version = "0.3.1", optional = true }
 chainhook-types = { version = "1.3.3", path = "../chainhook-types-rs" }

--- a/components/chainhook-sdk/Cargo.toml
+++ b/components/chainhook-sdk/Cargo.toml
@@ -12,8 +12,7 @@ serde = { version = "1", features = ["rc"] }
 serde_json = { version = "1", features = ["arbitrary_precision"] }
 serde-hex = "0.1.0"
 serde_derive = "1"
-# stacks-codec = { git = "https://github.com/hirosystems/clarinet.git", branch = "feat/stacks-codec" }
-stacks-codec = { path = "../../../clarinet/components/stacks-codec" }
+stacks-codec = { git = "https://github.com/hirosystems/clarinet.git", branch = "feat/stacks-codec" }
 # hiro-system-kit = { version = "0.1.0", path = "../../../clarinet/components/hiro-system-kit" }
 hiro-system-kit = { version = "0.3.1", optional = true }
 chainhook-types = { version = "1.3.3", path = "../chainhook-types-rs" }

--- a/components/chainhook-sdk/Cargo.toml
+++ b/components/chainhook-sdk/Cargo.toml
@@ -12,10 +12,10 @@ serde = { version = "1", features = ["rc"] }
 serde_json = { version = "1", features = ["arbitrary_precision"] }
 serde-hex = "0.1.0"
 serde_derive = "1"
-stacks-rpc-client = { version = "2", git = "https://github.com/hirosystems/clarinet.git" }
-hiro-system-kit = { version = "0.3.4", optional = true }
-# stacks-rpc-client = { version = "1", path = "../../../clarinet/components/stacks-rpc-client" }
+# stacks-codec = { git = "https://github.com/hirosystems/clarinet.git", branch = "feat/handle-epoch3_0" }
+stacks-codec = { version = "2", path = "../../../clarinet/components/stacks-codec" }
 # hiro-system-kit = { version = "0.1.0", path = "../../../clarinet/components/hiro-system-kit" }
+hiro-system-kit = { version = "0.3.1", optional = true }
 chainhook-types = { version = "1.3.3", path = "../chainhook-types-rs" }
 rocket = { version = "=0.5.0-rc.3", features = ["json"] }
 bitcoincore-rpc = "0.18.0"

--- a/components/chainhook-sdk/src/chainhooks/stacks/mod.rs
+++ b/components/chainhook-sdk/src/chainhooks/stacks/mod.rs
@@ -12,8 +12,8 @@ use hiro_system_kit::slog;
 use regex::Regex;
 use reqwest::{Client, Method};
 use serde_json::Value as JsonValue;
-use stacks_rpc_client::clarity::codec::StacksMessageCodec;
-use stacks_rpc_client::clarity::vm::types::{CharType, SequenceData, Value as ClarityValue};
+use stacks_codec::clarity::codec::StacksMessageCodec;
+use stacks_codec::clarity::vm::types::{CharType, SequenceData, Value as ClarityValue};
 use std::collections::{BTreeMap, HashMap};
 use std::io::Cursor;
 

--- a/components/chainhook-sdk/src/indexer/mod.rs
+++ b/components/chainhook-sdk/src/indexer/mod.rs
@@ -23,92 +23,47 @@ pub struct AssetClassCache {
 }
 
 #[derive(Deserialize, Debug, Clone)]
-pub struct PoxInfo {
-    pub contract_id: String,
-    pub pox_activation_threshold_ustx: u64,
+pub struct PoxConfig {
     pub first_burnchain_block_height: u32,
-    pub current_burnchain_block_height: u32,
     pub prepare_phase_block_length: u32,
     pub reward_phase_block_length: u32,
-    pub reward_slots: u32,
-    pub reward_cycle_id: u32,
-    pub reward_cycle_length: u32,
-    pub total_liquid_supply_ustx: u64,
-    pub current_cycle: CurrentPoxCycle,
-    pub next_cycle: NextPoxCycle,
 }
 
-impl PoxInfo {
-    pub fn mainnet_default() -> PoxInfo {
-        PoxInfo {
-            contract_id: "SP000000000000000000002Q6VF78.pox-3".into(),
-            pox_activation_threshold_ustx: 0,
+impl PoxConfig {
+    pub fn mainnet_default() -> PoxConfig {
+        PoxConfig {
             first_burnchain_block_height: 666050,
             prepare_phase_block_length: 100,
             reward_phase_block_length: 2000,
-            reward_slots: 4000,
-            total_liquid_supply_ustx: 1368787887756275,
-            ..Default::default()
         }
     }
 
-    pub fn testnet_default() -> PoxInfo {
-        PoxInfo {
-            contract_id: "ST000000000000000000002AMW42H.pox-3".into(),
-            pox_activation_threshold_ustx: 0,
-            current_burnchain_block_height: 2000000,
+    pub fn testnet_default() -> PoxConfig {
+        PoxConfig {
             first_burnchain_block_height: 2000000,
             prepare_phase_block_length: 50,
             reward_phase_block_length: 1000,
-            reward_slots: 2000,
-            total_liquid_supply_ustx: 41412139686144074,
-            ..Default::default()
         }
     }
 
-    pub fn devnet_default() -> PoxInfo {
+    pub fn devnet_default() -> PoxConfig {
         Self::default()
     }
 }
 
-impl Default for PoxInfo {
-    fn default() -> PoxInfo {
-        PoxInfo {
-            contract_id: "ST000000000000000000002AMW42H.pox".into(),
-            pox_activation_threshold_ustx: 0,
-            current_burnchain_block_height: 100,
+impl Default for PoxConfig {
+    fn default() -> PoxConfig {
+        PoxConfig {
             first_burnchain_block_height: 100,
             prepare_phase_block_length: 4,
             reward_phase_block_length: 6,
-            reward_cycle_length: 10,
-            reward_slots: 10,
-            total_liquid_supply_ustx: 1000000000000000,
-            reward_cycle_id: 0,
-            current_cycle: CurrentPoxCycle::default(),
-            next_cycle: NextPoxCycle::default(),
         }
     }
 }
 
-#[derive(Deserialize, Debug, Clone, Default)]
-pub struct CurrentPoxCycle {
-    pub id: u64,
-    pub min_threshold_ustx: u64,
-    pub stacked_ustx: u64,
-    pub is_pox_active: bool,
-}
-
-#[derive(Deserialize, Debug, Clone, Default)]
-pub struct NextPoxCycle {
-    pub min_threshold_ustx: u64,
-    pub stacked_ustx: u64,
-    pub blocks_until_prepare_phase: i16,
-    pub blocks_until_reward_phase: i16,
-}
-
 pub struct StacksChainContext {
     asset_class_map: HashMap<String, AssetClassCache>,
-    pox_info: PoxInfo,
+    pox_info: PoxConfig,
 }
 
 impl StacksChainContext {
@@ -116,9 +71,9 @@ impl StacksChainContext {
         StacksChainContext {
             asset_class_map: HashMap::new(),
             pox_info: match network {
-                StacksNetwork::Mainnet => PoxInfo::mainnet_default(),
-                StacksNetwork::Testnet => PoxInfo::testnet_default(),
-                _ => PoxInfo::devnet_default(),
+                StacksNetwork::Mainnet => PoxConfig::mainnet_default(),
+                StacksNetwork::Testnet => PoxConfig::testnet_default(),
+                _ => PoxConfig::devnet_default(),
             },
         }
     }
@@ -232,7 +187,7 @@ impl Indexer {
             .process_microblocks(microblocks, ctx)
     }
 
-    pub fn get_pox_info(&mut self) -> PoxInfo {
+    pub fn get_pox_info(&mut self) -> PoxConfig {
         self.stacks_context.pox_info.clone()
     }
 }

--- a/components/chainhook-sdk/src/indexer/mod.rs
+++ b/components/chainhook-sdk/src/indexer/mod.rs
@@ -63,14 +63,14 @@ impl Default for PoxConfig {
 
 pub struct StacksChainContext {
     asset_class_map: HashMap<String, AssetClassCache>,
-    pox_info: PoxConfig,
+    pox_config: PoxConfig,
 }
 
 impl StacksChainContext {
     pub fn new(network: &StacksNetwork) -> StacksChainContext {
         StacksChainContext {
             asset_class_map: HashMap::new(),
-            pox_info: match network {
+            pox_config: match network {
                 StacksNetwork::Mainnet => PoxConfig::mainnet_default(),
                 StacksNetwork::Testnet => PoxConfig::testnet_default(),
                 _ => PoxConfig::devnet_default(),
@@ -187,8 +187,8 @@ impl Indexer {
             .process_microblocks(microblocks, ctx)
     }
 
-    pub fn get_pox_info(&mut self) -> PoxConfig {
-        self.stacks_context.pox_info.clone()
+    pub fn get_pox_config(&mut self) -> PoxConfig {
+        self.stacks_context.pox_config.clone()
     }
 }
 

--- a/components/chainhook-sdk/src/indexer/mod.rs
+++ b/components/chainhook-sdk/src/indexer/mod.rs
@@ -12,7 +12,6 @@ use hiro_system_kit::slog;
 use rocket::serde::json::Value as JsonValue;
 
 use stacks::StacksBlockPool;
-use stacks_codec::pox::PoxInfo;
 use std::collections::{HashMap, VecDeque};
 
 use self::fork_scratch_pad::ForkScratchPad;
@@ -21,6 +20,90 @@ use self::fork_scratch_pad::ForkScratchPad;
 pub struct AssetClassCache {
     pub symbol: String,
     pub decimals: u8,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct PoxInfo {
+    pub contract_id: String,
+    pub pox_activation_threshold_ustx: u64,
+    pub first_burnchain_block_height: u32,
+    pub current_burnchain_block_height: u32,
+    pub prepare_phase_block_length: u32,
+    pub reward_phase_block_length: u32,
+    pub reward_slots: u32,
+    pub reward_cycle_id: u32,
+    pub reward_cycle_length: u32,
+    pub total_liquid_supply_ustx: u64,
+    pub current_cycle: CurrentPoxCycle,
+    pub next_cycle: NextPoxCycle,
+}
+
+impl PoxInfo {
+    pub fn mainnet_default() -> PoxInfo {
+        PoxInfo {
+            contract_id: "SP000000000000000000002Q6VF78.pox-3".into(),
+            pox_activation_threshold_ustx: 0,
+            first_burnchain_block_height: 666050,
+            prepare_phase_block_length: 100,
+            reward_phase_block_length: 2000,
+            reward_slots: 4000,
+            total_liquid_supply_ustx: 1368787887756275,
+            ..Default::default()
+        }
+    }
+
+    pub fn testnet_default() -> PoxInfo {
+        PoxInfo {
+            contract_id: "ST000000000000000000002AMW42H.pox-3".into(),
+            pox_activation_threshold_ustx: 0,
+            current_burnchain_block_height: 2000000,
+            first_burnchain_block_height: 2000000,
+            prepare_phase_block_length: 50,
+            reward_phase_block_length: 1000,
+            reward_slots: 2000,
+            total_liquid_supply_ustx: 41412139686144074,
+            ..Default::default()
+        }
+    }
+
+    pub fn devnet_default() -> PoxInfo {
+        Self::default()
+    }
+}
+
+impl Default for PoxInfo {
+    fn default() -> PoxInfo {
+        PoxInfo {
+            contract_id: "ST000000000000000000002AMW42H.pox".into(),
+            pox_activation_threshold_ustx: 0,
+            current_burnchain_block_height: 100,
+            first_burnchain_block_height: 100,
+            prepare_phase_block_length: 4,
+            reward_phase_block_length: 6,
+            reward_cycle_length: 10,
+            reward_slots: 10,
+            total_liquid_supply_ustx: 1000000000000000,
+            reward_cycle_id: 0,
+            current_cycle: CurrentPoxCycle::default(),
+            next_cycle: NextPoxCycle::default(),
+        }
+    }
+}
+
+#[derive(Deserialize, Debug, Clone, Default)]
+pub struct CurrentPoxCycle {
+    pub id: u64,
+    pub min_threshold_ustx: u64,
+    pub stacked_ustx: u64,
+    pub is_pox_active: bool,
+}
+
+#[derive(Deserialize, Debug, Clone, Default)]
+pub struct NextPoxCycle {
+    pub min_threshold_ustx: u64,
+    pub stacked_ustx: u64,
+    pub blocks_until_prepare_phase: i16,
+    pub blocks_until_reward_phase: i16,
 }
 
 pub struct StacksChainContext {

--- a/components/chainhook-sdk/src/indexer/mod.rs
+++ b/components/chainhook-sdk/src/indexer/mod.rs
@@ -12,7 +12,7 @@ use hiro_system_kit::slog;
 use rocket::serde::json::Value as JsonValue;
 
 use stacks::StacksBlockPool;
-use stacks_rpc_client::PoxInfo;
+use stacks_codec::pox::PoxInfo;
 use std::collections::{HashMap, VecDeque};
 
 use self::fork_scratch_pad::ForkScratchPad;

--- a/components/chainhook-sdk/src/indexer/stacks/mod.rs
+++ b/components/chainhook-sdk/src/indexer/stacks/mod.rs
@@ -1,6 +1,7 @@
 mod blocks_pool;
 
 pub use blocks_pool::StacksBlockPool;
+use stacks_codec::codec::{StacksTransaction, TransactionAuth, TransactionPayload};
 
 use crate::chainhooks::stacks::try_decode_clarity_value;
 use crate::indexer::AssetClassCache;
@@ -10,9 +11,8 @@ use chainhook_types::*;
 use hiro_system_kit::slog;
 use rocket::serde::json::Value as JsonValue;
 use rocket::serde::Deserialize;
-use stacks_rpc_client::clarity::codec::StacksMessageCodec;
-use stacks_rpc_client::clarity::codec::{StacksTransaction, TransactionAuth, TransactionPayload};
-use stacks_rpc_client::clarity::vm::types::{SequenceData, Value as ClarityValue};
+use stacks_codec::clarity::codec::StacksMessageCodec;
+use stacks_codec::clarity::vm::types::{SequenceData, Value as ClarityValue};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::convert::TryInto;
 use std::io::Cursor;

--- a/components/chainhook-sdk/src/indexer/stacks/mod.rs
+++ b/components/chainhook-sdk/src/indexer/stacks/mod.rs
@@ -327,12 +327,12 @@ pub fn standardize_stacks_block(
     chain_ctx: &mut StacksChainContext,
     ctx: &Context,
 ) -> Result<StacksBlockData, String> {
-    let pox_cycle_length: u64 = (chain_ctx.pox_info.prepare_phase_block_length
-        + chain_ctx.pox_info.reward_phase_block_length)
+    let pox_cycle_length: u64 = (chain_ctx.pox_config.prepare_phase_block_length
+        + chain_ctx.pox_config.reward_phase_block_length)
         .into();
     let current_len = u64::saturating_sub(
         block.burn_block_height,
-        1 + (chain_ctx.pox_info.first_burnchain_block_height as u64),
+        1 + (chain_ctx.pox_config.first_burnchain_block_height as u64),
     );
     let pox_cycle_id: u32 = (current_len / pox_cycle_length).try_into().unwrap_or(0);
     let mut events: HashMap<&String, Vec<&NewEvent>> = HashMap::new();

--- a/components/chainhook-sdk/src/lib.rs
+++ b/components/chainhook-sdk/src/lib.rs
@@ -17,7 +17,6 @@ pub extern crate bitcoincore_rpc;
 pub extern crate bitcoincore_rpc_json;
 pub extern crate dashmap;
 pub extern crate fxhash;
-pub extern crate stacks_rpc_client;
 
 pub use bitcoincore_rpc::bitcoin;
 pub use chainhook_types as types;
@@ -27,10 +26,3 @@ pub mod indexer;
 pub mod monitoring;
 pub mod observer;
 pub mod utils;
-
-// TODO
-// pub mod clarity {
-//     pub use stacks_rpc_client::clarity::stacks_common::*;
-//     pub use stacks_rpc_client::clarity::vm::*;
-//     pub use stacks_rpc_client::clarity::*;
-// }

--- a/components/chainhook-sdk/src/observer/http.rs
+++ b/components/chainhook-sdk/src/observer/http.rs
@@ -156,13 +156,13 @@ pub fn handle_new_stacks_block(
     // Standardize the structure of the block, and identify the
     // kind of update that this new block would imply, taking
     // into account the last 7 blocks.
-    // TODO(lgalabru): use _pox_info
-    let (_pox_info, chain_event) = match indexer_rw_lock.inner().write() {
+    // TODO(lgalabru): use _pox_config
+    let (_pox_config, chain_event) = match indexer_rw_lock.inner().write() {
         Ok(mut indexer) => {
-            let pox_info = indexer.get_pox_info();
+            let pox_config = indexer.get_pox_config();
             let chain_event =
                 indexer.handle_stacks_marshalled_block(marshalled_block.into_inner(), &ctx);
-            (pox_info, chain_event)
+            (pox_config, chain_event)
         }
         Err(e) => {
             ctx.try_log(|logger| {


### PR DESCRIPTION
### Description

- replace the stacks-rpc-client dependency in favor of stacks-codec one
- replace `stacks_rpc_client::PoxInfo` with a new `PoxConfig` struct
  - I think that PoxInfo was misused here, it's supposed to represent the live state of pox on the chain, while chainhook-sdk is just storing some default config values
