### PR TITLE
fix: limit scope of stacks_rw_db usage to free lock

### DIFF
--- a/components/chainhook-cli/src/service/mod.rs
+++ b/components/chainhook-cli/src/service/mod.rs
@@ -476,7 +476,7 @@ impl Service {
                                 ) {
                                     error!(
                                         self.ctx.expect_logger(),
-                                        "unable add confirmed entries to stacks db: {}", e
+                                        "unable to add confirmed entries to stacks db: {}", e
                                     );
                                 };
                                 if let Err(e) = draft_entries_in_stacks_blocks(
@@ -486,7 +486,7 @@ impl Service {
                                 ) {
                                     error!(
                                         self.ctx.expect_logger(),
-                                        "unable add unconfirmed entries to stacks db: {}", e
+                                        "unable to add unconfirmed entries to stacks db: {}", e
                                     );
                                 };
                             }
@@ -498,7 +498,7 @@ impl Service {
                                 ) {
                                     error!(
                                         self.ctx.expect_logger(),
-                                        "unable add confirmed entries to stacks db: {}", e
+                                        "unable to add confirmed entries to stacks db: {}", e
                                     );
                                 };
                                 if let Err(e) = draft_entries_in_stacks_blocks(
@@ -508,7 +508,7 @@ impl Service {
                                 ) {
                                     error!(
                                         self.ctx.expect_logger(),
-                                        "unable add unconfirmed entries to stacks db: {}", e
+                                        "unable to add unconfirmed entries to stacks db: {}", e
                                     );
                                 };
                             }


### PR DESCRIPTION
Every 32 stacks blocks, Chainhook attempts to check for a new archive file to fix any potential holes in the database. This process requires readwrite access to the stacks.rocksdb. However, the process that called this subprocess already had a readwrite instance of the database open, which was preventing the lock from being cleared.

This PR sets the scope of the initial usage of the db in order to free up the lock.