### PR TITLE
feat: add Bitcoin transaction index to typescript client

### DIFF
--- a/components/client/typescript/package-lock.json
+++ b/components/client/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hirosystems/chainhook-client",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hirosystems/chainhook-client",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "license": "Apache 2.0",
       "dependencies": {
         "@fastify/type-provider-typebox": "^3.2.0",

--- a/components/client/typescript/package.json
+++ b/components/client/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hirosystems/chainhook-client",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Chainhook TypeScript client",
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",

--- a/components/client/typescript/src/schemas/bitcoin/payload.ts
+++ b/components/client/typescript/src/schemas/bitcoin/payload.ts
@@ -5,6 +5,7 @@ import {
   TransactionIdentifierSchema,
   RosettaOperationSchema,
 } from '../common';
+import { BitcoinIfThisSchema } from './if_this';
 
 export const BitcoinInscriptionRevealedSchema = Type.Object({
   content_bytes: Type.String(),
@@ -115,12 +116,14 @@ export const BitcoinBrc20OperationSchema = Type.Union([
   BitcoinBrc20TransferOperationSchema,
   BitcoinBrc20TransferSendOperationSchema,
 ]);
+export type BitcoinBrc20Operation = Static<typeof BitcoinBrc20OperationSchema>;
 
 export const BitcoinTransactionMetadataSchema = Type.Object({
   ordinal_operations: Type.Array(BitcoinOrdinalOperationSchema),
   brc20_operation: Type.Optional(BitcoinBrc20OperationSchema),
   outputs: Type.Optional(Type.Array(BitcoinOutputSchema)),
   proof: Nullable(Type.String()),
+  index: Type.Integer(),
 });
 export type BitcoinTransactionMetadata = Static<typeof BitcoinTransactionMetadataSchema>;
 
@@ -139,3 +142,14 @@ export const BitcoinEventSchema = Type.Object({
   metadata: Type.Any(),
 });
 export type BitcoinEvent = Static<typeof BitcoinEventSchema>;
+
+export const BitcoinPayloadSchema = Type.Object({
+  apply: Type.Array(BitcoinEventSchema),
+  rollback: Type.Array(BitcoinEventSchema),
+  chainhook: Type.Object({
+    uuid: Type.String(),
+    predicate: BitcoinIfThisSchema,
+    is_streaming_blocks: Type.Boolean(),
+  }),
+});
+export type BitcoinPayload = Static<typeof BitcoinPayloadSchema>;

--- a/components/client/typescript/src/schemas/payload.ts
+++ b/components/client/typescript/src/schemas/payload.ts
@@ -1,18 +1,6 @@
 import { Static, Type } from '@sinclair/typebox';
-import { StacksEventSchema } from './stacks/payload';
-import { BitcoinEventSchema } from './bitcoin/payload';
-import { BitcoinIfThisSchema } from './bitcoin/if_this';
-import { StacksIfThisSchema } from './stacks/if_this';
+import { StacksPayloadSchema } from './stacks/payload';
+import { BitcoinPayloadSchema } from './bitcoin/payload';
 
-const EventArray = Type.Union([Type.Array(StacksEventSchema), Type.Array(BitcoinEventSchema)]);
-
-export const PayloadSchema = Type.Object({
-  apply: EventArray,
-  rollback: EventArray,
-  chainhook: Type.Object({
-    uuid: Type.String(),
-    predicate: Type.Union([BitcoinIfThisSchema, StacksIfThisSchema]),
-    is_streaming_blocks: Type.Boolean(),
-  }),
-});
+export const PayloadSchema = Type.Union([BitcoinPayloadSchema, StacksPayloadSchema]);
 export type Payload = Static<typeof PayloadSchema>;

--- a/components/client/typescript/src/schemas/stacks/payload.ts
+++ b/components/client/typescript/src/schemas/stacks/payload.ts
@@ -7,6 +7,7 @@ import {
 } from '../common';
 import { StacksTransactionEventSchema } from './tx_events';
 import { StacksTransactionKindSchema } from './tx_kind';
+import { StacksIfThisSchema } from './if_this';
 
 export const StacksExecutionCostSchema = Type.Optional(
   Type.Object({
@@ -75,3 +76,14 @@ export const StacksEventSchema = Type.Object({
   metadata: StacksEventMetadataSchema,
 });
 export type StacksEvent = Static<typeof StacksEventSchema>;
+
+export const StacksPayloadSchema = Type.Object({
+  apply: Type.Array(StacksEventSchema),
+  rollback: Type.Array(StacksEventSchema),
+  chainhook: Type.Object({
+    uuid: Type.String(),
+    predicate: StacksIfThisSchema,
+    is_streaming_blocks: Type.Boolean(),
+  }),
+});
+export type StacksPayload = Static<typeof StacksPayloadSchema>;


### PR DESCRIPTION
Also separate `StacksPayload` and `BitcoinPayload` into separate types for easier client-side inference.
Bump version to 1.8.0