### PR TITLE
[WIP] feat: predicate chaining

### DIFF
--- a/components/chainhook-sdk/src/chainhooks/bitcoin/mod.rs
+++ b/components/chainhook-sdk/src/chainhooks/bitcoin/mod.rs
@@ -1,7 +1,7 @@
 use super::types::{
     BitcoinChainhookSpecification, BitcoinPredicateType, DescriptorMatchingRule, ExactMatchingRule,
     HookAction, InputPredicate, MatchingRule, OrdinalOperations, OrdinalsMetaProtocol,
-    OutputPredicate, StacksOperations,
+    OutputPredicate, StacksOperations, TxinPredicate,
 };
 use crate::utils::Context;
 
@@ -27,10 +27,11 @@ use reqwest::RequestBuilder;
 
 use hex::FromHex;
 
-pub struct BitcoinTriggerChainhook<'a> {
-    pub chainhook: &'a BitcoinChainhookSpecification,
-    pub apply: Vec<(Vec<&'a BitcoinTransactionData>, &'a BitcoinBlockData)>,
-    pub rollback: Vec<(Vec<&'a BitcoinTransactionData>, &'a BitcoinBlockData)>,
+#[derive(Clone, Debug)]
+pub struct BitcoinTriggerChainhook {
+    pub chainhook: BitcoinChainhookSpecification,
+    pub apply: Vec<(Vec<BitcoinTransactionData>, BitcoinBlockData)>,
+    pub rollback: Vec<(Vec<BitcoinTransactionData>, BitcoinBlockData)>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -52,9 +53,7 @@ pub struct BitcoinChainhookOccurrencePayload {
 }
 
 impl BitcoinChainhookOccurrencePayload {
-    pub fn from_trigger<'a>(
-        trigger: BitcoinTriggerChainhook<'a>,
-    ) -> BitcoinChainhookOccurrencePayload {
+    pub fn from_trigger(trigger: BitcoinTriggerChainhook) -> BitcoinChainhookOccurrencePayload {
         BitcoinChainhookOccurrencePayload {
             apply: trigger
                 .apply
@@ -93,96 +92,120 @@ pub enum BitcoinChainhookOccurrence {
     Data(BitcoinChainhookOccurrencePayload),
 }
 
-pub fn evaluate_bitcoin_chainhooks_on_chain_event<'a>(
-    chain_event: &'a BitcoinChainEvent,
-    active_chainhooks: &Vec<&'a BitcoinChainhookSpecification>,
+pub fn evaluate_bitcoin_chainhooks_on_chain_event(
+    chain_event: BitcoinChainEvent,
+    chainhook: BitcoinChainhookSpecification,
     ctx: &Context,
 ) -> (
-    Vec<BitcoinTriggerChainhook<'a>>,
-    BTreeMap<&'a str, &'a BlockIdentifier>,
-    BTreeMap<&'a str, &'a BlockIdentifier>,
+    Vec<BitcoinTriggerChainhook>,
+    BTreeMap<String, BlockIdentifier>,
+    BTreeMap<String, BlockIdentifier>,
+    Vec<BitcoinChainhookSpecification>,
 ) {
     let mut evaluated_predicates = BTreeMap::new();
     let mut triggered_predicates = vec![];
     let mut expired_predicates = BTreeMap::new();
+    let mut new_chainhooks = vec![];
 
     match chain_event {
         BitcoinChainEvent::ChainUpdatedWithBlocks(event) => {
-            for chainhook in active_chainhooks.iter() {
-                let mut apply = vec![];
-                let rollback = vec![];
-                let end_block = chainhook.end_block.unwrap_or(u64::MAX);
+            let mut apply = vec![];
+            let rollback = vec![];
+            let end_block = chainhook.end_block.unwrap_or(u64::MAX);
 
-                for block in event.new_blocks.iter() {
-                    evaluated_predicates.insert(chainhook.uuid.as_str(), &block.block_identifier);
-                    if end_block >= block.block_identifier.index {
-                        let mut hits = vec![];
-                        for tx in block.transactions.iter() {
-                            if chainhook.predicate.evaluate_transaction_predicate(&tx, ctx) {
-                                hits.push(tx);
-                            }
+            for block in event.new_blocks.into_iter() {
+                evaluated_predicates.insert(chainhook.uuid.clone(), block.block_identifier.clone());
+                if end_block >= block.block_identifier.index.clone() {
+                    let mut hits = vec![];
+                    for tx in block.transactions.clone().into_iter() {
+                        let (has_match, new_predicate) =
+                            chainhook.predicate.evaluate_transaction_predicate(&tx, ctx);
+                        if has_match {
+                            hits.push(tx);
                         }
-                        if hits.len() > 0 {
-                            apply.push((hits, block));
+                        if let Some(new_predicate) = new_predicate {
+                            let mut new_chainhook = chainhook.clone();
+                            new_chainhook.predicate = new_predicate;
+                            new_chainhooks.push(new_chainhook)
                         }
-                    } else {
-                        expired_predicates.insert(chainhook.uuid.as_str(), &block.block_identifier);
                     }
-                }
-
-                if !apply.is_empty() {
-                    triggered_predicates.push(BitcoinTriggerChainhook {
-                        chainhook,
-                        apply,
-                        rollback,
-                    })
+                    if hits.len() > 0 {
+                        apply.push((hits, block));
+                    }
+                } else {
+                    expired_predicates
+                        .insert(chainhook.uuid.clone(), block.block_identifier.clone());
                 }
             }
-        }
-        BitcoinChainEvent::ChainUpdatedWithReorg(event) => {
-            for chainhook in active_chainhooks.iter() {
-                let mut apply = vec![];
-                let mut rollback = vec![];
-                let end_block = chainhook.end_block.unwrap_or(u64::MAX);
 
-                for block in event.blocks_to_rollback.iter() {
-                    if end_block >= block.block_identifier.index {
-                        let mut hits = vec![];
-                        for tx in block.transactions.iter() {
-                            if chainhook.predicate.evaluate_transaction_predicate(&tx, ctx) {
-                                hits.push(tx);
-                            }
+            if !apply.is_empty() {
+                triggered_predicates.push(BitcoinTriggerChainhook {
+                    chainhook: chainhook,
+                    apply,
+                    rollback,
+                })
+            }
+        }
+
+        BitcoinChainEvent::ChainUpdatedWithReorg(event) => {
+            let mut apply = vec![];
+            let mut rollback = vec![];
+            let end_block = chainhook.end_block.unwrap_or(u64::MAX);
+
+            // todo: think through rollback
+            for block in event.blocks_to_rollback.into_iter() {
+                if end_block >= block.block_identifier.index {
+                    let mut hits = vec![];
+                    for tx in block.transactions.clone().into_iter() {
+                        let (has_match, new_predicate) =
+                            chainhook.predicate.evaluate_transaction_predicate(&tx, ctx);
+                        if has_match {
+                            hits.push(tx);
                         }
-                        if hits.len() > 0 {
-                            rollback.push((hits, block));
+                        if let Some(new_predicate) = new_predicate {
+                            let mut new_chainhook = chainhook.clone();
+                            new_chainhook.predicate = new_predicate;
+                            new_chainhooks.push(new_chainhook)
                         }
-                    } else {
-                        expired_predicates.insert(chainhook.uuid.as_str(), &block.block_identifier);
                     }
-                }
-                for block in event.blocks_to_apply.iter() {
-                    evaluated_predicates.insert(chainhook.uuid.as_str(), &block.block_identifier);
-                    if end_block >= block.block_identifier.index {
-                        let mut hits = vec![];
-                        for tx in block.transactions.iter() {
-                            if chainhook.predicate.evaluate_transaction_predicate(&tx, ctx) {
-                                hits.push(tx);
-                            }
-                        }
-                        if hits.len() > 0 {
-                            apply.push((hits, block));
-                        }
-                    } else {
-                        expired_predicates.insert(chainhook.uuid.as_str(), &block.block_identifier);
+                    if hits.len() > 0 {
+                        rollback.push((hits, block));
                     }
+                } else {
+                    expired_predicates
+                        .insert(chainhook.uuid.clone(), block.block_identifier.clone());
                 }
-                if !apply.is_empty() || !rollback.is_empty() {
-                    triggered_predicates.push(BitcoinTriggerChainhook {
-                        chainhook,
-                        apply,
-                        rollback,
-                    })
+            }
+            for block in event.blocks_to_apply.into_iter() {
+                evaluated_predicates.insert(chainhook.uuid.clone(), block.block_identifier.clone());
+                if end_block >= block.block_identifier.index {
+                    let mut hits = vec![];
+                    for tx in block.transactions.clone().into_iter() {
+                        let (has_match, new_predicate) =
+                            chainhook.predicate.evaluate_transaction_predicate(&tx, ctx);
+                        if has_match {
+                            hits.push(tx);
+                        }
+                        if let Some(new_predicate) = new_predicate {
+                            let mut new_chainhook = chainhook.clone();
+                            new_chainhook.predicate = new_predicate;
+                            new_chainhooks.push(new_chainhook)
+                        }
+                    }
+                    if hits.len() > 0 {
+                        apply.push((hits, block));
+                    }
+                } else {
+                    expired_predicates
+                        .insert(chainhook.uuid.clone(), block.block_identifier.clone());
                 }
+            }
+            if !apply.is_empty() || !rollback.is_empty() {
+                triggered_predicates.push(BitcoinTriggerChainhook {
+                    chainhook,
+                    apply,
+                    rollback,
+                })
             }
         }
     }
@@ -190,16 +213,17 @@ pub fn evaluate_bitcoin_chainhooks_on_chain_event<'a>(
         triggered_predicates,
         evaluated_predicates,
         expired_predicates,
+        new_chainhooks,
     )
 }
 
-pub fn serialize_bitcoin_payload_to_json<'a>(
-    trigger: &BitcoinTriggerChainhook<'a>,
-    proofs: &HashMap<&'a TransactionIdentifier, String>,
+pub fn serialize_bitcoin_payload_to_json(
+    trigger: BitcoinTriggerChainhook,
+    proofs: &HashMap<TransactionIdentifier, String>,
 ) -> JsonValue {
-    let predicate_spec = trigger.chainhook;
+    let predicate_spec = &trigger.chainhook;
     json!({
-        "apply": trigger.apply.iter().map(|(transactions, block)| {
+        "apply": trigger.clone().apply.iter().map(|(transactions, block)| {
             json!({
                 "block_identifier": block.block_identifier,
                 "parent_block_identifier": block.parent_block_identifier,
@@ -225,10 +249,10 @@ pub fn serialize_bitcoin_payload_to_json<'a>(
     })
 }
 
-pub fn serialize_bitcoin_transactions_to_json<'a>(
+pub fn serialize_bitcoin_transactions_to_json(
     predicate_spec: &BitcoinChainhookSpecification,
-    transactions: &Vec<&BitcoinTransactionData>,
-    proofs: &HashMap<&'a TransactionIdentifier, String>,
+    transactions: &Vec<BitcoinTransactionData>,
+    proofs: &HashMap<TransactionIdentifier, String>,
 ) -> Vec<JsonValue> {
     transactions
         .into_iter()
@@ -301,9 +325,9 @@ pub fn serialize_bitcoin_transactions_to_json<'a>(
         .collect::<Vec<_>>()
 }
 
-pub fn handle_bitcoin_hook_action<'a>(
-    trigger: BitcoinTriggerChainhook<'a>,
-    proofs: &HashMap<&'a TransactionIdentifier, String>,
+pub fn handle_bitcoin_hook_action(
+    trigger: BitcoinTriggerChainhook,
+    proofs: &HashMap<TransactionIdentifier, String>,
 ) -> Result<BitcoinChainhookOccurrence, String> {
     match &trigger.chainhook.action {
         HookAction::HttpPost(http) => {
@@ -312,8 +336,9 @@ pub fn handle_bitcoin_hook_action<'a>(
                 .map_err(|e| format!("unable to build http client: {}", e.to_string()))?;
             let host = format!("{}", http.url);
             let method = Method::POST;
-            let body = serde_json::to_vec(&serialize_bitcoin_payload_to_json(&trigger, proofs))
-                .map_err(|e| format!("unable to serialize payload {}", e.to_string()))?;
+            let body =
+                serde_json::to_vec(&serialize_bitcoin_payload_to_json(trigger.clone(), proofs))
+                    .map_err(|e| format!("unable to serialize payload {}", e.to_string()))?;
             let request = client
                 .request(method, &host)
                 .header("Content-Type", "application/json")
@@ -324,8 +349,9 @@ pub fn handle_bitcoin_hook_action<'a>(
             Ok(BitcoinChainhookOccurrence::Http(request, data))
         }
         HookAction::FileAppend(disk) => {
-            let bytes = serde_json::to_vec(&serialize_bitcoin_payload_to_json(&trigger, proofs))
-                .map_err(|e| format!("unable to serialize payload {}", e.to_string()))?;
+            let bytes =
+                serde_json::to_vec(&serialize_bitcoin_payload_to_json(trigger.clone(), proofs))
+                    .map_err(|e| format!("unable to serialize payload {}", e.to_string()))?;
             Ok(BitcoinChainhookOccurrence::File(
                 disk.path.to_string(),
                 bytes,

--- a/components/chainhook-sdk/src/chainhooks/bitcoin/tests.rs
+++ b/components/chainhook-sdk/src/chainhooks/bitcoin/tests.rs
@@ -135,8 +135,8 @@ fn script_pubkey_evaluation(output: OutputPredicate, script_pubkey: &str, matche
         logger: None,
         tracer: false,
     };
-
-    assert_eq!(matches, predicate.evaluate_transaction_predicate(&tx, &ctx));
+    let (actual_matches, _) = predicate.evaluate_transaction_predicate(&tx, &ctx);
+    assert_eq!(matches, actual_matches);
 }
 
 #[test_case(
@@ -161,7 +161,7 @@ fn it_serdes_occurrence_payload(
         3,
     );
     let block = generate_test_bitcoin_block(0, 0, vec![transaction.clone()], None);
-    let chainhook = &BitcoinChainhookSpecification {
+    let chainhook = BitcoinChainhookSpecification {
         uuid: "uuid".into(),
         owner_uuid: None,
         name: "name".into(),
@@ -182,14 +182,11 @@ fn it_serdes_occurrence_payload(
     };
     let trigger = BitcoinTriggerChainhook {
         chainhook,
-        apply: vec![(vec![&transaction], &block)],
+        apply: vec![(vec![transaction], block)],
         rollback: vec![],
     };
-    let payload = serde_json::to_vec(&serialize_bitcoin_payload_to_json(
-        &trigger,
-        &HashMap::new(),
-    ))
-    .unwrap();
+    let payload =
+        serde_json::to_vec(&serialize_bitcoin_payload_to_json(trigger, &HashMap::new())).unwrap();
 
     let _: BitcoinChainhookOccurrencePayload = serde_json::from_slice(&payload[..]).unwrap();
 }

--- a/components/chainhook-sdk/src/chainhooks/types.rs
+++ b/components/chainhook-sdk/src/chainhooks/types.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashSet, VecDeque};
 
 use chainhook_types::{BitcoinNetwork, StacksNetwork};
 use reqwest::Url;
@@ -12,14 +12,14 @@ use crate::utils::MAX_BLOCK_HEIGHTS_ENTRIES;
 #[derive(Deserialize, Debug, Clone)]
 pub struct ChainhookConfig {
     pub stacks_chainhooks: Vec<StacksChainhookSpecification>,
-    pub bitcoin_chainhooks: Vec<BitcoinChainhookSpecification>,
+    pub bitcoin_chainhooks: VecDeque<BitcoinChainhookSpecification>,
 }
 
 impl ChainhookConfig {
     pub fn new() -> ChainhookConfig {
         ChainhookConfig {
             stacks_chainhooks: vec![],
-            bitcoin_chainhooks: vec![],
+            bitcoin_chainhooks: VecDeque::new(),
         }
     }
 
@@ -36,7 +36,7 @@ impl ChainhookConfig {
             }
             ChainhookFullSpecification::Bitcoin(hook) => {
                 let spec = hook.into_selected_network_specification(networks.0)?;
-                self.bitcoin_chainhooks.push(spec.clone());
+                self.bitcoin_chainhooks.push_back(spec.clone());
                 ChainhookSpecification::Bitcoin(spec)
             }
         };
@@ -74,7 +74,7 @@ impl ChainhookConfig {
             }
             ChainhookSpecification::Bitcoin(spec) => {
                 let spec = spec.clone();
-                self.bitcoin_chainhooks.push(spec);
+                self.bitcoin_chainhooks.push_back(spec);
             }
         };
         Ok(())
@@ -104,7 +104,7 @@ impl ChainhookConfig {
         while i < self.bitcoin_chainhooks.len() {
             if self.bitcoin_chainhooks[i].uuid == hook_uuid {
                 let hook = self.bitcoin_chainhooks.remove(i);
-                return Some(hook);
+                return hook;
             } else {
                 i += 1;
             }

--- a/components/chainhook-sdk/src/chainhooks/types.rs
+++ b/components/chainhook-sdk/src/chainhooks/types.rs
@@ -667,7 +667,8 @@ impl TryFrom<u8> for StacksOpcodes {
 #[serde(rename_all = "snake_case")]
 pub struct TxinPredicate {
     pub txid: String,
-    pub vout: u32,
+    pub vout: Option<u32>,
+    pub follow_inputs: Option<bool>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, JsonSchema)]

--- a/components/chainhook-sdk/src/monitoring.rs
+++ b/components/chainhook-sdk/src/monitoring.rs
@@ -208,6 +208,21 @@ impl PrometheusMonitoring {
         g
     }
 
+    pub fn initialize(
+        &self,
+        stx_predicates: u64,
+        btc_predicates: u64,
+        initial_stx_block: Option<u64>,
+    ) {
+        self.stx_metrics_set_registered_predicates(stx_predicates);
+        self.btc_metrics_set_registered_predicates(btc_predicates);
+        if let Some(initial_stx_block) = initial_stx_block {
+            self.stx_metrics_block_received(initial_stx_block);
+            self.stx_metrics_block_appeneded(initial_stx_block);
+            self.stx_metrics_block_evaluated(initial_stx_block);
+        }
+    }
+
     // stx helpers
     pub fn stx_metrics_deregister_predicate(&self) {
         self.stx_registered_predicates.dec();

--- a/components/chainhook-sdk/src/observer/mod.rs
+++ b/components/chainhook-sdk/src/observer/mod.rs
@@ -522,21 +522,19 @@ pub fn start_event_observer(
 
 pub async fn start_bitcoin_event_observer(
     config: EventObserverConfig,
-    _observer_commands_tx: Sender<ObserverCommand>,
+    observer_commands_tx: Sender<ObserverCommand>,
     observer_commands_rx: Receiver<ObserverCommand>,
     observer_events_tx: Option<crossbeam_channel::Sender<ObserverEvent>>,
     observer_sidecar: Option<ObserverSidecar>,
     ctx: Context,
 ) -> Result<(), Box<dyn Error>> {
     let chainhook_store = config.get_chainhook_store();
-
     #[cfg(feature = "zeromq")]
     {
         let ctx_moved = ctx.clone();
         let config_moved = config.clone();
         let _ = hiro_system_kit::thread_named("ZMQ handler").spawn(move || {
-            let future =
-                zmq::start_zeromq_runloop(&config_moved, _observer_commands_tx, &ctx_moved);
+            let future = zmq::start_zeromq_runloop(&config_moved, observer_commands_tx, &ctx_moved);
             let _ = hiro_system_kit::nestable_block_on(future);
         });
     }

--- a/components/client/typescript/package-lock.json
+++ b/components/client/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hirosystems/chainhook-client",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hirosystems/chainhook-client",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "license": "Apache 2.0",
       "dependencies": {
         "@fastify/type-provider-typebox": "^3.2.0",

--- a/components/client/typescript/package.json
+++ b/components/client/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hirosystems/chainhook-client",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Chainhook TypeScript client",
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",

--- a/components/client/typescript/src/schemas/bitcoin/payload.ts
+++ b/components/client/typescript/src/schemas/bitcoin/payload.ts
@@ -5,6 +5,7 @@ import {
   TransactionIdentifierSchema,
   RosettaOperationSchema,
 } from '../common';
+import { BitcoinIfThisSchema } from './if_this';
 
 export const BitcoinInscriptionRevealedSchema = Type.Object({
   content_bytes: Type.String(),
@@ -115,12 +116,14 @@ export const BitcoinBrc20OperationSchema = Type.Union([
   BitcoinBrc20TransferOperationSchema,
   BitcoinBrc20TransferSendOperationSchema,
 ]);
+export type BitcoinBrc20Operation = Static<typeof BitcoinBrc20OperationSchema>;
 
 export const BitcoinTransactionMetadataSchema = Type.Object({
   ordinal_operations: Type.Array(BitcoinOrdinalOperationSchema),
   brc20_operation: Type.Optional(BitcoinBrc20OperationSchema),
   outputs: Type.Optional(Type.Array(BitcoinOutputSchema)),
   proof: Nullable(Type.String()),
+  index: Type.Integer(),
 });
 export type BitcoinTransactionMetadata = Static<typeof BitcoinTransactionMetadataSchema>;
 
@@ -139,3 +142,14 @@ export const BitcoinEventSchema = Type.Object({
   metadata: Type.Any(),
 });
 export type BitcoinEvent = Static<typeof BitcoinEventSchema>;
+
+export const BitcoinPayloadSchema = Type.Object({
+  apply: Type.Array(BitcoinEventSchema),
+  rollback: Type.Array(BitcoinEventSchema),
+  chainhook: Type.Object({
+    uuid: Type.String(),
+    predicate: BitcoinIfThisSchema,
+    is_streaming_blocks: Type.Boolean(),
+  }),
+});
+export type BitcoinPayload = Static<typeof BitcoinPayloadSchema>;

--- a/components/client/typescript/src/schemas/payload.ts
+++ b/components/client/typescript/src/schemas/payload.ts
@@ -1,18 +1,6 @@
 import { Static, Type } from '@sinclair/typebox';
-import { StacksEventSchema } from './stacks/payload';
-import { BitcoinEventSchema } from './bitcoin/payload';
-import { BitcoinIfThisSchema } from './bitcoin/if_this';
-import { StacksIfThisSchema } from './stacks/if_this';
+import { StacksPayloadSchema } from './stacks/payload';
+import { BitcoinPayloadSchema } from './bitcoin/payload';
 
-const EventArray = Type.Union([Type.Array(StacksEventSchema), Type.Array(BitcoinEventSchema)]);
-
-export const PayloadSchema = Type.Object({
-  apply: EventArray,
-  rollback: EventArray,
-  chainhook: Type.Object({
-    uuid: Type.String(),
-    predicate: Type.Union([BitcoinIfThisSchema, StacksIfThisSchema]),
-    is_streaming_blocks: Type.Boolean(),
-  }),
-});
+export const PayloadSchema = Type.Union([BitcoinPayloadSchema, StacksPayloadSchema]);
 export type Payload = Static<typeof PayloadSchema>;

--- a/components/client/typescript/src/schemas/stacks/payload.ts
+++ b/components/client/typescript/src/schemas/stacks/payload.ts
@@ -7,6 +7,7 @@ import {
 } from '../common';
 import { StacksTransactionEventSchema } from './tx_events';
 import { StacksTransactionKindSchema } from './tx_kind';
+import { StacksIfThisSchema } from './if_this';
 
 export const StacksExecutionCostSchema = Type.Optional(
   Type.Object({
@@ -75,3 +76,14 @@ export const StacksEventSchema = Type.Object({
   metadata: StacksEventMetadataSchema,
 });
 export type StacksEvent = Static<typeof StacksEventSchema>;
+
+export const StacksPayloadSchema = Type.Object({
+  apply: Type.Array(StacksEventSchema),
+  rollback: Type.Array(StacksEventSchema),
+  chainhook: Type.Object({
+    uuid: Type.String(),
+    predicate: StacksIfThisSchema,
+    is_streaming_blocks: Type.Boolean(),
+  }),
+});
+export type StacksPayload = Static<typeof StacksPayloadSchema>;


### PR DESCRIPTION
This PR introduces the concept of predicate chaining - one predicate can create subsequent predicates.

The first example of this is the bitcoin input predicate. It now has the "follow_inputs" field:
```
"if_this": {
  "scope": "inputs",
  "txid": {
    "txid": "0x32ed7f5c82d51d3ffdb8544190704e6b11e06d6d675fc527633adbde6a468e0f",
    "follow_inputs": true
  }
}
```

Consider the following chain of transactions:
```
block1 - tx1
block2 - tx2 (with input.previous_output == tx1)
block3 - tx3 (with input.previous_output == tx2)
...
```

Previously, this predicate would just allow you to find any bitcoin transactions that have a transaction input with `previous_output.txid` equal to the provided `txid`. So for the example, we could put the `txid` for `tx1`, and the predicate would match `tx2`, since it has an input that uses `tx1` for its prevout.

Now, by setting the `follow_inputs` field to `true`, you can get all transactions that use `txid` as input, _and all transactions that use those subsequent transaction's id's as inputs_. So for our example, providing a `txid` of `tx1` for the predicate would match for `tx2` (because it's prevout has `tx1`) and `tx3` (because _it's_ output has a prevout of `tx2`) and so on.

---
## Notes
Here are some notes on where this PR is, since it doesn't look like I'll be able to finish this during my tenure at Hiro 😞 

As this PR currently is, predicate chaining works in that we have a predicate that can create more downstream predicates. The part that is not yet working, and will probably get kind of messy is handling reorgs.

Reorgs will not only have to check against predicates to see if the user needs to be notified of blocks to roll back, but it also needs to actually delete predicates that were generated from reorged blocks.

Maybe the new predicates that can create other predicates have some metadata with them when they're created, such as the identifier of the block that created the predicate? As this is done, we should also implement a more general interface for this new type of predicate.
