### PR TITLE
chore: update predicate scanning status on every trigger

### DIFF
--- a/components/chainhook-cli/src/scan/bitcoin.rs
+++ b/components/chainhook-cli/src/scan/bitcoin.rs
@@ -101,7 +101,7 @@ pub async fn scan_bitcoin_chainstate_via_rpc_using_predicate(
     let mut loop_did_trigger = false;
     while let Some(current_block_height) = block_heights_to_scan.pop_front() {
         if let Some(ref mut predicates_db_conn) = predicates_db_conn {
-            if number_of_blocks_scanned % 10 == 0 
+            if number_of_blocks_scanned % 100 == 0 
                 || number_of_blocks_scanned == 0
                 // if the last loop did trigger a predicate, update the status
                 || loop_did_trigger

--- a/components/chainhook-cli/src/scan/stacks.rs
+++ b/components/chainhook-cli/src/scan/stacks.rs
@@ -227,7 +227,7 @@ pub async fn scan_stacks_chainstate_via_rocksdb_using_predicate(
     let mut loop_did_trigger = false;
     while let Some(current_block_height) = block_heights_to_scan.pop_front() {
         if let Some(ref mut predicates_db_conn) = predicates_db_conn {
-            if number_of_blocks_scanned % 10 == 0
+            if number_of_blocks_scanned % 1000 == 0
                 || number_of_blocks_scanned == 0
                 // if the last loop did trigger a predicate, update the status
                 || loop_did_trigger


### PR DESCRIPTION
The predicate status is used to report data to users and to pick back up where the service left off on a restart. This change updates the scanning predicate status to be updated on every successful trigger of a scanning predicate, to be sure we don't scan blocks twice on a restart (if the status was set to a previous block, we'd start on that block at startup)