### PR TITLE
refactor: use clarity crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -496,6 +496,7 @@ dependencies = [
  "bitcoincore-rpc",
  "bitcoincore-rpc-json",
  "chainhook-types",
+ "clarity",
  "crossbeam-channel",
  "dashmap",
  "futures",

--- a/components/chainhook-sdk/Cargo.toml
+++ b/components/chainhook-sdk/Cargo.toml
@@ -13,6 +13,10 @@ serde_json = { version = "1", features = ["arbitrary_precision"] }
 serde-hex = "0.1.0"
 serde_derive = "1"
 stacks-codec = "2.4.1"
+clarity = { git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-develop", package = "clarity", default-features = false, features = [
+    "canonical",
+    "log",
+] }
 hiro-system-kit = { version = "0.3.4", optional = true }
 chainhook-types = { version = "1.3.6", path = "../chainhook-types-rs" }
 rocket = { version = "=0.5.0", features = ["json"] }

--- a/components/chainhook-sdk/src/chainhooks/stacks/mod.rs
+++ b/components/chainhook-sdk/src/chainhooks/stacks/mod.rs
@@ -10,16 +10,16 @@ use chainhook_types::{
     StacksTransactionEvent, StacksTransactionEventPayload, StacksTransactionKind,
     TransactionIdentifier,
 };
+use clarity::codec::StacksMessageCodec;
+use clarity::vm::types::{
+    CharType, PrincipalData, QualifiedContractIdentifier, SequenceData, Value as ClarityValue,
+};
+use clarity::vm::ClarityName;
 use hiro_system_kit::slog;
 use regex::Regex;
 use reqwest::{Client, Method};
 use schemars::JsonSchema;
 use serde_json::Value as JsonValue;
-use stacks_codec::clarity::codec::StacksMessageCodec;
-use stacks_codec::clarity::vm::types::PrincipalData;
-use stacks_codec::clarity::vm::types::QualifiedContractIdentifier;
-use stacks_codec::clarity::vm::types::{CharType, SequenceData, Value as ClarityValue};
-use stacks_codec::clarity::ClarityName;
 use std::collections::{BTreeMap, HashMap};
 use std::io::Cursor;
 

--- a/components/chainhook-sdk/src/indexer/stacks/mod.rs
+++ b/components/chainhook-sdk/src/indexer/stacks/mod.rs
@@ -1,18 +1,18 @@
 mod blocks_pool;
 
 pub use blocks_pool::StacksBlockPool;
-use stacks_codec::codec::{StacksTransaction, TransactionAuth, TransactionPayload};
 
 use crate::chainhooks::stacks::try_decode_clarity_value;
 use crate::indexer::AssetClassCache;
 use crate::indexer::{IndexerConfig, StacksChainContext};
 use crate::utils::Context;
 use chainhook_types::*;
+use clarity::codec::StacksMessageCodec;
+use clarity::vm::types::{SequenceData, Value as ClarityValue};
 use hiro_system_kit::slog;
 use rocket::serde::json::Value as JsonValue;
 use rocket::serde::Deserialize;
-use stacks_codec::clarity::codec::StacksMessageCodec;
-use stacks_codec::clarity::vm::types::{SequenceData, Value as ClarityValue};
+use stacks_codec::codec::{StacksTransaction, TransactionAuth, TransactionPayload};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::convert::TryInto;
 use std::io::Cursor;


### PR DESCRIPTION
I'm willing to remove this pattern from stacks-codec and clarity repl
https://github.com/hirosystems/clarinet/blob/ce1ffeaaf645de2d9a581d1d727e660cacb1e288/components/stacks-codec/src/lib.rs#L6-L10
```rust
pub mod clarity {
    #![allow(ambiguous_glob_reexports)]
    pub use ::clarity::types::*;
    pub use ::clarity::vm::*;
    pub use ::clarity::*;
}
```

It's error prone, adds complexity, for no value in this context. It's easier for packages to simply rely on the clarity crates (that will soon™ be imported from crates.io)

