### PR TITLE
feat: parse `/stackerdb_chunks` Stacks node event

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        suite: [cli, sdk]
+        include:
+          - suite: cli
+            features: redis_tests
+          - suite: sdk
+            features: stacks-signers
     defaults:
       run:
         working-directory: ./components/chainhook-${{ matrix.suite }}
@@ -39,7 +43,6 @@ jobs:
         if: matrix.suite == 'cli'
         run: |
           sudo apt-get install -y redis-server
-          echo "TARPAULIN_FLAGS=--features redis_tests" >> $GITHUB_ENV
 
       - name: Cache cargo
         uses: actions/cache@v4
@@ -61,7 +64,7 @@ jobs:
 
       - name: Run tests
         run: |
-          cargo tarpaulin --skip-clean --out lcov ${{ env.TARPAULIN_FLAGS }} -- --test-threads=1
+          cargo tarpaulin --skip-clean --out lcov --features ${{ matrix.features }} -- --test-threads=1
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3538,8 +3538,8 @@ dependencies = [
 
 [[package]]
 name = "stacks-codec"
-version = "2.8.0"
-source = "git+https://github.com/hirosystems/clarinet.git#b84e0d0228a2220c860150939bdc5207e8b505ff"
+version = "2.7.0"
+source = "git+https://github.com/hirosystems/clarinet.git?rev=3a2f9136abd85b265e538fbe51c808e9c09a06cb#3a2f9136abd85b265e538fbe51c808e9c09a06cb"
 dependencies = [
  "clarity",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,4 @@ default-members = ["components/chainhook-cli", "components/chainhook-sdk"]
 resolver = "2"
 
 [patch.crates-io]
-stacks-codec = { git = "https://github.com/hirosystems/clarinet.git" }
+stacks-codec = { git = "https://github.com/hirosystems/clarinet.git", rev = "3a2f9136abd85b265e538fbe51c808e9c09a06cb" }

--- a/components/chainhook-cli/Cargo.toml
+++ b/components/chainhook-cli/Cargo.toml
@@ -16,7 +16,7 @@ serde-redis = "0.12.0"
 hex = "0.4.3"
 rand = "0.8.5"
 chainhook-sdk = { version = "0.12.6", default-features = false, features = [
-    "zeromq",
+    "zeromq", "stacks-signers"
 ], path = "../chainhook-sdk" }
 hiro-system-kit = "0.3.4"
 # hiro-system-kit = { path = "../../../clarinet/components/hiro-system-kit" }

--- a/components/chainhook-cli/src/service/mod.rs
+++ b/components/chainhook-cli/src/service/mod.rs
@@ -549,7 +549,7 @@ impl Service {
                             StacksChainEvent::ChainUpdatedWithMicroblocks(_)
                             | StacksChainEvent::ChainUpdatedWithMicroblocksReorg(_) => {},
                             StacksChainEvent::ChainUpdatedWithStackerDbChunks(data) => {
-                                // TODO: Store data
+                                // TODO(rafaelcr): Store signer data.
                             }
                         },
                         Err(e) => {
@@ -620,7 +620,7 @@ impl Service {
                             StacksChainEvent::ChainUpdatedWithMicroblocks(_)
                             | StacksChainEvent::ChainUpdatedWithMicroblocksReorg(_) => {},
                             StacksChainEvent::ChainUpdatedWithStackerDbChunks(data) => {
-                                // TODO: Send via HTTP payload
+                                // TODO(rafaelcr): Send via HTTP payload.
                             },
                         };
                         update_status_from_report(

--- a/components/chainhook-cli/src/service/mod.rs
+++ b/components/chainhook-cli/src/service/mod.rs
@@ -547,7 +547,10 @@ impl Service {
                                 };
                             }
                             StacksChainEvent::ChainUpdatedWithMicroblocks(_)
-                            | StacksChainEvent::ChainUpdatedWithMicroblocksReorg(_) => {}
+                            | StacksChainEvent::ChainUpdatedWithMicroblocksReorg(_) => {},
+                            StacksChainEvent::ChainUpdatedWithStackerDbChunks(data) => {
+                                // TODO: Store data
+                            }
                         },
                         Err(e) => {
                             error!(
@@ -615,7 +618,10 @@ impl Service {
                                 }
                             }
                             StacksChainEvent::ChainUpdatedWithMicroblocks(_)
-                            | StacksChainEvent::ChainUpdatedWithMicroblocksReorg(_) => {}
+                            | StacksChainEvent::ChainUpdatedWithMicroblocksReorg(_) => {},
+                            StacksChainEvent::ChainUpdatedWithStackerDbChunks(data) => {
+                                // TODO: Send via HTTP payload
+                            },
                         };
                         update_status_from_report(
                             Chain::Stacks,

--- a/components/chainhook-sdk/Cargo.toml
+++ b/components/chainhook-sdk/Cargo.toml
@@ -52,5 +52,6 @@ test-case = "3.1.0"
 [features]
 default = ["hiro-system-kit/log"]
 zeromq = ["zmq"]
+stacks-signers = []
 debug = ["hiro-system-kit/debug"]
 release = ["hiro-system-kit/release_debug", "hiro-system-kit/full_log_level_prefix"]

--- a/components/chainhook-sdk/src/chainhooks/stacks/mod.rs
+++ b/components/chainhook-sdk/src/chainhooks/stacks/mod.rs
@@ -719,7 +719,10 @@ pub fn evaluate_stacks_chainhooks_on_chain_event<'a>(
                     })
                 }
             }
-        }
+        },
+        StacksChainEvent::ChainUpdatedWithStackerDbChunks(data) => {
+            // TODO: Support predicates to send this data
+        },
     }
     (
         triggered_predicates,

--- a/components/chainhook-sdk/src/indexer/mod.rs
+++ b/components/chainhook-sdk/src/indexer/mod.rs
@@ -171,6 +171,7 @@ impl Indexer {
     pub fn handle_stacks_marshalled_stackerdb_chunk(
         &mut self,
         marshalled_stackerdb_chunks: JsonValue,
+        receipt_time: u64,
         ctx: &Context,
     ) -> Result<Option<StacksChainEvent>, String> {
         use chainhook_types::StacksChainUpdatedWithStackerDbChunksData;
@@ -178,6 +179,7 @@ impl Indexer {
         let chunks = stacks::standardize_stacks_marshalled_stackerdb_chunks(
             &self.config,
             marshalled_stackerdb_chunks,
+            receipt_time,
             &mut self.stacks_context,
             ctx,
         )?;

--- a/components/chainhook-sdk/src/indexer/mod.rs
+++ b/components/chainhook-sdk/src/indexer/mod.rs
@@ -173,12 +173,21 @@ impl Indexer {
         marshalled_stackerdb_chunks: JsonValue,
         ctx: &Context,
     ) -> Result<Option<StacksChainEvent>, String> {
+        use chainhook_types::StacksChainUpdatedWithStackerDbChunksData;
+
         let chunks = stacks::standardize_stacks_marshalled_stackerdb_chunks(
             &self.config,
             marshalled_stackerdb_chunks,
             &mut self.stacks_context,
             ctx,
         )?;
+        if chunks.len() > 0 {
+            Ok(Some(StacksChainEvent::ChainUpdatedWithStackerDbChunks(
+                StacksChainUpdatedWithStackerDbChunksData { chunks },
+            )))
+        } else {
+            Ok(None)
+        }
     }
 }
 

--- a/components/chainhook-sdk/src/indexer/mod.rs
+++ b/components/chainhook-sdk/src/indexer/mod.rs
@@ -109,7 +109,6 @@ impl Indexer {
         header: BlockHeader,
         ctx: &Context,
     ) -> Result<Option<BlockchainEvent>, String> {
-        
         self.bitcoin_blocks_pool.process_header(header, ctx)
     }
 
@@ -166,6 +165,20 @@ impl Indexer {
 
     pub fn get_pox_config(&mut self) -> PoxConfig {
         self.stacks_context.pox_config.clone()
+    }
+
+    #[cfg(feature = "stacks-signers")]
+    pub fn handle_stacks_marshalled_stackerdb_chunk(
+        &mut self,
+        marshalled_stackerdb_chunks: JsonValue,
+        ctx: &Context,
+    ) -> Result<Option<StacksChainEvent>, String> {
+        let chunks = stacks::standardize_stacks_marshalled_stackerdb_chunks(
+            &self.config,
+            marshalled_stackerdb_chunks,
+            &mut self.stacks_context,
+            ctx,
+        )?;
     }
 }
 

--- a/components/chainhook-sdk/src/indexer/stacks/mod.rs
+++ b/components/chainhook-sdk/src/indexer/stacks/mod.rs
@@ -641,7 +641,7 @@ pub fn standardize_stacks_stackerdb_chunks(
             SignerMessage::BlockResponse(block_response) => match block_response {
                 BlockResponse::Accepted((block_hash, sig)) => StacksSignerMessage::BlockResponse(
                     BlockResponseData::Accepted(BlockAcceptedResponse {
-                        block_hash: block_hash.to_hex(),
+                        signer_signature_hash: block_hash.to_hex(),
                         sig: sig.to_hex(),
                     }),
                 ),
@@ -763,7 +763,8 @@ pub fn get_signer_pubkey_from_stackerdb_chunk_slot(
 
     let mut digest_bytes = slot.slot_id.to_be_bytes().to_vec();
     digest_bytes.extend(slot.version.to_be_bytes().to_vec());
-    digest_bytes.extend(data_bytes.clone());
+    let data_bytes_hashed = Sha512Trunc256Sum::from_data(&data_bytes).to_bytes();
+    digest_bytes.extend(data_bytes_hashed);
     let digest = Sha512Trunc256Sum::from_data(&digest_bytes).to_bytes();
 
     let sig_bytes =

--- a/components/chainhook-sdk/src/indexer/stacks/mod.rs
+++ b/components/chainhook-sdk/src/indexer/stacks/mod.rs
@@ -595,19 +595,21 @@ pub fn standardize_stacks_microblock_trail(
 pub fn standardize_stacks_marshalled_stackerdb_chunks(
     indexer_config: &IndexerConfig,
     marshalled_stackerdb_chunks: JsonValue,
+    receipt_time: u64,
     chain_ctx: &mut StacksChainContext,
     ctx: &Context,
 ) -> Result<Vec<StacksStackerDbChunk>, String> {
     let mut stackerdb_chunks: NewStackerDbChunks =
         serde_json::from_value(marshalled_stackerdb_chunks)
             .map_err(|e| format!("unable to parse stackerdb chunks {e}"))?;
-    standardize_stacks_stackerdb_chunks(indexer_config, &mut stackerdb_chunks, chain_ctx, ctx)
+    standardize_stacks_stackerdb_chunks(indexer_config, &mut stackerdb_chunks, receipt_time, chain_ctx, ctx)
 }
 
 #[cfg(feature = "stacks-signers")]
 pub fn standardize_stacks_stackerdb_chunks(
     indexer_config: &IndexerConfig,
     stackerdb_chunks: &mut NewStackerDbChunks,
+    receipt_time: u64,
     chain_ctx: &mut StacksChainContext,
     ctx: &Context,
 ) -> Result<Vec<StacksStackerDbChunk>, String> {
@@ -706,6 +708,7 @@ pub fn standardize_stacks_stackerdb_chunks(
             sig: slot.sig.clone(),
             pubkey: get_signer_pubkey_from_stackerdb_chunk_slot(slot, &data_bytes)?,
             message,
+            receipt_time,
         });
     }
 
@@ -740,7 +743,7 @@ pub fn standardize_stacks_nakamoto_block(block: &NakamotoBlock) -> NakamotoBlock
                 .serialize_to_vec()
                 .to_hex_string(Case::Lower),
         },
-        // FIXME: Should we parse these?
+        // TODO(rafaelcr): Parse and return transactions.
         transactions: vec![],
     }
 }

--- a/components/chainhook-sdk/src/indexer/stacks/mod.rs
+++ b/components/chainhook-sdk/src/indexer/stacks/mod.rs
@@ -593,25 +593,22 @@ pub fn standardize_stacks_microblock_trail(
 
 #[cfg(feature = "stacks-signers")]
 pub fn standardize_stacks_marshalled_stackerdb_chunks(
-    indexer_config: &IndexerConfig,
+    _indexer_config: &IndexerConfig,
     marshalled_stackerdb_chunks: JsonValue,
     receipt_time: u64,
-    chain_ctx: &mut StacksChainContext,
-    ctx: &Context,
+    _chain_ctx: &mut StacksChainContext,
+    _ctx: &Context,
 ) -> Result<Vec<StacksStackerDbChunk>, String> {
     let mut stackerdb_chunks: NewStackerDbChunks =
         serde_json::from_value(marshalled_stackerdb_chunks)
             .map_err(|e| format!("unable to parse stackerdb chunks {e}"))?;
-    standardize_stacks_stackerdb_chunks(indexer_config, &mut stackerdb_chunks, receipt_time, chain_ctx, ctx)
+    standardize_stacks_stackerdb_chunks(&mut stackerdb_chunks, receipt_time)
 }
 
 #[cfg(feature = "stacks-signers")]
 pub fn standardize_stacks_stackerdb_chunks(
-    indexer_config: &IndexerConfig,
-    stackerdb_chunks: &mut NewStackerDbChunks,
+    stackerdb_chunks: &NewStackerDbChunks,
     receipt_time: u64,
-    chain_ctx: &mut StacksChainContext,
-    ctx: &Context,
 ) -> Result<Vec<StacksStackerDbChunk>, String> {
     use stacks_codec::codec::BlockResponse;
     use stacks_codec::codec::RejectCode;
@@ -755,10 +752,11 @@ pub fn get_signer_pubkey_from_stackerdb_chunk_slot(
 ) -> Result<String, String> {
     use clarity::util::hash::Sha512Trunc256Sum;
     use miniscript::bitcoin::{
-        key::Secp256k1, secp256k1::{
+        key::Secp256k1,
+        secp256k1::{
             ecdsa::{RecoverableSignature, RecoveryId},
             Message,
-        }
+        },
     };
 
     let mut digest_bytes = slot.slot_id.to_be_bytes().to_vec();

--- a/components/chainhook-sdk/src/indexer/tests/helpers/stacks_events.rs
+++ b/components/chainhook-sdk/src/indexer/tests/helpers/stacks_events.rs
@@ -119,3 +119,29 @@ pub fn create_new_event_from_stacks_event(event: StacksTransactionEventPayload) 
         contract_event,
     }
 }
+
+#[cfg(feature = "stacks-signers")]
+pub fn create_new_stackerdb_chunk(
+    contract_name: String,
+    slot_sig: String,
+    slot_data: String,
+) -> crate::indexer::stacks::NewStackerDbChunks {
+    use crate::indexer::stacks::{
+        NewSignerModifiedSlot, NewStackerDbChunkIssuer, NewStackerDbChunksContractId,
+    };
+    crate::indexer::stacks::NewStackerDbChunks {
+        contract_id: NewStackerDbChunksContractId {
+            name: contract_name,
+            issuer: vec![NewStackerDbChunkIssuer {
+                issuer_id: 26,
+                slots: vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            }],
+        },
+        modified_slots: vec![NewSignerModifiedSlot {
+            sig: slot_sig,
+            data: slot_data,
+            slot_id: 1,
+            version: 141,
+        }],
+    }
+}

--- a/components/chainhook-sdk/src/observer/http.rs
+++ b/components/chainhook-sdk/src/observer/http.rs
@@ -189,7 +189,7 @@ pub fn handle_stackerdb_chunks(
     // Standardize the structure of the StackerDB chunk, and identify the kind of update that this new message would imply.
     let chain_event = match indexer_rw_lock.inner().write() {
         Ok(mut indexer) => indexer
-            .handle_stacks_marshalled_microblock_trail(payload.into_inner(), ctx),
+            .handle_stacks_marshalled_stackerdb_chunk(payload.into_inner(), ctx),
         Err(e) => {
             return error_response(format!("Unable to acquire background_job_tx: {e}"), ctx);
         }

--- a/components/chainhook-sdk/src/observer/mod.rs
+++ b/components/chainhook-sdk/src/observer/mod.rs
@@ -997,9 +997,11 @@ pub async fn start_stacks_event_observer(
         http::handle_new_attachement,
         http::handle_mined_block,
         http::handle_mined_microblock,
-        http::handle_stackerdb_chunks,
     ];
-
+    #[cfg(feature = "stacks-signers")]
+    {
+        routes.append(&mut routes![http::handle_stackerdb_chunks]);
+    }
     if bitcoin_rpc_proxy_enabled {
         routes.append(&mut routes![http::handle_bitcoin_rpc_call]);
         routes.append(&mut routes![http::handle_bitcoin_wallet_rpc_call]);

--- a/components/chainhook-sdk/src/observer/mod.rs
+++ b/components/chainhook-sdk/src/observer/mod.rs
@@ -997,6 +997,7 @@ pub async fn start_stacks_event_observer(
         http::handle_new_attachement,
         http::handle_mined_block,
         http::handle_mined_microblock,
+        http::handle_stackerdb_chunks,
     ];
 
     if bitcoin_rpc_proxy_enabled {

--- a/components/chainhook-types-rs/src/lib.rs
+++ b/components/chainhook-types-rs/src/lib.rs
@@ -9,12 +9,14 @@ mod events;
 mod ordinals;
 mod processors;
 mod rosetta;
+mod signers;
 
 pub use contract_interface::*;
 pub use events::*;
 pub use ordinals::*;
 pub use processors::*;
 pub use rosetta::*;
+pub use signers::*;
 
 pub const DEFAULT_STACKS_NODE_RPC: &str = "http://localhost:20443";
 

--- a/components/chainhook-types-rs/src/rosetta.rs
+++ b/components/chainhook-types-rs/src/rosetta.rs
@@ -1,7 +1,7 @@
 use super::bitcoin::{TxIn, TxOut};
 use crate::contract_interface::ContractInterface;
 use crate::ordinals::OrdinalOperation;
-use crate::{events::*, Brc20Operation, DEFAULT_STACKS_NODE_RPC};
+use crate::{events::*, Brc20Operation, StacksSignerMessage, StacksStackerDbChunk, DEFAULT_STACKS_NODE_RPC};
 use schemars::JsonSchema;
 use std::cmp::Ordering;
 use std::collections::HashSet;
@@ -667,6 +667,11 @@ pub struct BitcoinChainUpdatedWithReorgData {
     pub confirmed_blocks: Vec<BitcoinBlockData>,
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct StacksChainUpdatedWithStackerDbChunksData {
+    pub chunks: Vec<StacksStackerDbChunk>,
+}
+
 #[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub enum StacksChainEvent {
@@ -674,6 +679,7 @@ pub enum StacksChainEvent {
     ChainUpdatedWithReorg(StacksChainUpdatedWithReorgData),
     ChainUpdatedWithMicroblocks(StacksChainUpdatedWithMicroblocksData),
     ChainUpdatedWithMicroblocksReorg(StacksChainUpdatedWithMicroblocksReorgData),
+    ChainUpdatedWithStackerDbChunks(StacksChainUpdatedWithStackerDbChunksData),
 }
 
 impl StacksChainEvent {
@@ -703,6 +709,7 @@ impl StacksChainEvent {
                 .microblocks_to_apply
                 .first()
                 .and_then(|b| Some(&b.metadata.anchor_block_identifier)),
+            StacksChainEvent::ChainUpdatedWithStackerDbChunks(_) => None,
         }
     }
 }

--- a/components/chainhook-types-rs/src/rosetta.rs
+++ b/components/chainhook-types-rs/src/rosetta.rs
@@ -1,7 +1,7 @@
 use super::bitcoin::{TxIn, TxOut};
 use crate::contract_interface::ContractInterface;
 use crate::ordinals::OrdinalOperation;
-use crate::{events::*, Brc20Operation, StacksSignerMessage, StacksStackerDbChunk, DEFAULT_STACKS_NODE_RPC};
+use crate::{events::*, Brc20Operation, StacksStackerDbChunk, DEFAULT_STACKS_NODE_RPC};
 use schemars::JsonSchema;
 use std::cmp::Ordering;
 use std::collections::HashSet;

--- a/components/chainhook-types-rs/src/signers.rs
+++ b/components/chainhook-types-rs/src/signers.rs
@@ -91,4 +91,5 @@ pub struct StacksStackerDbChunk {
     pub sig: String,
     pub pubkey: String,
     pub message: StacksSignerMessage,
+    pub receipt_time: u64,
 }

--- a/components/chainhook-types-rs/src/signers.rs
+++ b/components/chainhook-types-rs/src/signers.rs
@@ -1,0 +1,96 @@
+use crate::StacksTransactionData;
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct NakamotoBlockHeaderData {
+    pub version: u8,
+    pub chain_length: u64,
+    pub burn_spent: u64,
+    pub consensus_hash: String,
+    pub parent_block_id: String,
+    pub tx_merkle_root: String,
+    pub state_index_root: String,
+    pub timestamp: u64,
+    pub miner_signature: String,
+    pub signer_signature: Vec<String>,
+    pub pox_treatment: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct NakamotoBlockData {
+    pub header: NakamotoBlockHeaderData,
+    pub transactions: Vec<StacksTransactionData>,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct BlockProposalData {
+    pub block: NakamotoBlockData,
+    pub burn_height: u64,
+    pub reward_cycle: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct BlockAcceptedResponse {
+    pub block_hash: String,
+    pub sig: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub enum BlockValidationFailedCode {
+    BadBlockHash = 0,
+    BadTransaction = 1,
+    InvalidBlock = 2,
+    ChainstateError = 3,
+    UnknownParent = 4,
+    NonCanonicalTenure = 5,
+    NoSuchTenure = 6,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub enum BlockRejectReasonCode {
+    ValidationFailed(BlockValidationFailedCode),
+    ConnectivityIssues,
+    RejectedInPriorRound,
+    NoSortitionView,
+    SortitionViewMismatch,
+    TestingDirective,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct BlockRejectedResponse {
+    pub reason: String,
+    pub reason_code: BlockRejectReasonCode,
+    pub signer_signature_hash: String,
+    pub chain_id: u32,
+    pub signature: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub enum BlockResponseData {
+    Accepted(BlockAcceptedResponse),
+    Rejected(BlockRejectedResponse),
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct BlockPushedData {
+    pub block: NakamotoBlockData,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub enum StacksSignerMessage {
+    BlockProposal(BlockProposalData),
+    BlockResponse(BlockResponseData),
+    BlockPushed(BlockPushedData),
+    MockProposal,
+    MockSignature,
+    MockBlock,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct StacksStackerDbChunk {
+    pub contract: String,
+    pub message: StacksSignerMessage,
+    pub raw_data: String,
+    pub raw_sig: String,
+    pub slot_id: u64,
+    pub slot_version: u64,
+}

--- a/components/chainhook-types-rs/src/signers.rs
+++ b/components/chainhook-types-rs/src/signers.rs
@@ -23,6 +23,7 @@ pub struct NakamotoBlockData {
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct BlockProposalData {
+    // TODO(rafaelcr): Include `block_hash` and `index_block_hash`.
     pub block: NakamotoBlockData,
     pub burn_height: u64,
     pub reward_cycle: u64,
@@ -30,7 +31,7 @@ pub struct BlockProposalData {
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct BlockAcceptedResponse {
-    pub block_hash: String,
+    pub signer_signature_hash: String,
     pub sig: String,
 }
 

--- a/components/chainhook-types-rs/src/signers.rs
+++ b/components/chainhook-types-rs/src/signers.rs
@@ -88,9 +88,7 @@ pub enum StacksSignerMessage {
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct StacksStackerDbChunk {
     pub contract: String,
+    pub sig: String,
+    pub pubkey: String,
     pub message: StacksSignerMessage,
-    pub raw_data: String,
-    pub raw_sig: String,
-    pub slot_id: u64,
-    pub slot_version: u64,
 }


### PR DESCRIPTION
Starts listening to the new `/stackerdb_chunks` Stacks node event and parses the incoming message. Parsers are taken from the `stacks_codec` crate, which has been updated with the latest serializers.

For future PRs:
* Start integrating the signer messages into the predicates framework
* Store signer messages in a local SQLite DB for replay
* Expand unit tests to include full Stacks node integration tests