### PR TITLE
fix: denial of service in quinn-proto when using `Endpoint::retry()`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1901,7 +1901,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -2563,9 +2563,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba92fb39ec7ad06ca2582c0ca834dfeadcaf06ddfc8e635c80aa7e1c05315fdd"
+checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
 dependencies = [
  "bytes",
  "rand",


### PR DESCRIPTION
### Description

As of quinn-proto 0.11, it is possible for a server to `accept()`, `retry()`, `refuse()`, or `ignore()` an `Incoming` connection. However, calling `retry()` on an unvalidated connection exposes the server to a likely panic in the following situations:
 * Calling refuse or ignore on the resulting validated connection, if a duplicate initial packet is received
  * This issue can go undetected until a server's refuse()/ignore() code path is exercised, such as to stop a denial of service attack.

 * Accepting when the initial packet for the resulting validated connection fails to decrypt or exhausts connection IDs, if a similar initial packet that successfully decrypts and doesn't exhaust connection IDs is received.
  * This issue can go undetected if clients are well-behaved.
  * 
```js
 match route_to {
                RouteDatagramTo::Incoming(incoming_idx) => {
                    let incoming_buffer = &mut self.incoming_buffers[incoming_idx];
                    let config = &self.server_config.as_ref().unwrap();

                    if incoming_buffer
                        .total_bytes
                        .checked_add(datagram_len as u64)
                        .map_or(false, |n| n <= config.incoming_buffer_size)
                        && self
                            .all_incoming_buffers_total_bytes
                            .checked_add(datagram_len as u64)
                            .map_or(false, |n| n <= config.incoming_buffer_size_total)
                    {
```
[CWE-670](https://cwe.mitre.org/data/definitions/670.html)
[CVE-2024-45311](https://nvd.nist.gov/vuln/detail/CVE-2024-45311)

---

### Checklist

- [x] All tests pass
- [x] Tests added in this PR (if applicable)

