### PR TITLE
fix: signer pubkey calculation

### DIFF
--- a/components/chainhook-sdk/src/indexer/stacks/mod.rs
+++ b/components/chainhook-sdk/src/indexer/stacks/mod.rs
@@ -326,8 +326,8 @@ pub struct NewStackerDbChunksContractId {
 pub struct NewSignerModifiedSlot {
     pub sig: String,
     pub data: String,
-    pub slot_id: u64,
-    pub slot_version: u64,
+    pub slot_id: u32,
+    pub slot_version: u32,
 }
 
 #[cfg(feature = "stacks-signers")]

--- a/components/chainhook-sdk/src/indexer/tests/helpers/stacks_events.rs
+++ b/components/chainhook-sdk/src/indexer/tests/helpers/stacks_events.rs
@@ -119,32 +119,3 @@ pub fn create_new_event_from_stacks_event(event: StacksTransactionEventPayload) 
         contract_event,
     }
 }
-
-#[cfg(feature = "stacks-signers")]
-pub fn create_new_stackerdb_chunk(
-    contract_name: String,
-    slot_sig: String,
-    slot_data: String,
-) -> crate::indexer::stacks::NewStackerDbChunks {
-    use crate::indexer::stacks::{
-        NewSignerModifiedSlot, NewStackerDbChunkIssuerId, NewStackerDbChunkIssuerSlots,
-        NewStackerDbChunksContractId,
-    };
-    crate::indexer::stacks::NewStackerDbChunks {
-        contract_id: NewStackerDbChunksContractId {
-            name: contract_name,
-            issuer: (
-                NewStackerDbChunkIssuerId(26),
-                NewStackerDbChunkIssuerSlots(vec![
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                ]),
-            ),
-        },
-        modified_slots: vec![NewSignerModifiedSlot {
-            sig: slot_sig,
-            data: slot_data,
-            slot_id: 1,
-            slot_version: 141,
-        }],
-    }
-}


### PR DESCRIPTION
Fixes the `slot_id` and `slot_version` field sizes so the signer pubkey is calculated correctly