### PR TITLE
feat: dispatcher

### DIFF
--- a/components/chainhook-cli/src/service/mod.rs
+++ b/components/chainhook-cli/src/service/mod.rs
@@ -176,6 +176,7 @@ impl Service {
                     &config,
                     stacks_scan_op_rx,
                     observer_command_tx_moved.clone(),
+                    None,
                     &ctx,
                 );
                 // the scan runloop should loop forever; if it finishes, something is wrong
@@ -195,6 +196,7 @@ impl Service {
                     &config,
                     bitcoin_scan_op_rx,
                     observer_command_tx_moved.clone(),
+                    None,
                     &ctx,
                 );
                 // the scan runloop should loop forever; if it finishes, something is wrong
@@ -283,6 +285,7 @@ impl Service {
             moved_observer_command_tx,
             observer_command_rx,
             Some(observer_event_tx_moved),
+            None,
             None,
             Some(stacks_startup_context),
             self.ctx.clone(),

--- a/components/chainhook-sdk/src/dispatcher/mod.rs
+++ b/components/chainhook-sdk/src/dispatcher/mod.rs
@@ -1,0 +1,602 @@
+mod single_threaded;
+mod multi_threaded;
+
+
+use std::{fmt::Debug, sync::{atomic::{AtomicBool, AtomicI8, Ordering}, Arc, Mutex}, thread::{self, JoinHandle}};
+
+use crossbeam_channel::{unbounded, Sender};
+use hiro_system_kit::slog;
+use multi_threaded::multi_threaded_loop;
+use reqwest::{Client, RequestBuilder};
+use single_threaded::single_threaded_loop;
+use tokio::sync::mpsc::UnboundedReceiver;
+
+use crate::{
+    chainhooks::{bitcoin::BitcoinChainhookOccurrencePayload, stacks::StacksChainhookOccurrencePayload}, 
+    utils::{send_request, Context}
+};
+
+#[derive(Debug, Clone)]
+pub enum ChainhookOccurrencePayload {
+    Stacks(StacksChainhookOccurrencePayload),
+    Bitcoin(BitcoinChainhookOccurrencePayload),
+}
+
+pub trait ChainhookOccurrence {}
+
+impl ChainhookOccurrence for ChainhookOccurrencePayload {}
+
+#[derive(Debug)]
+struct LoopFeedBatch<T> {
+    pub requests: Vec<(Box<RequestBuilder>, Box<T>)>,
+    pub res_tx: ResultLocation,
+}
+
+#[derive(Debug)]
+struct LoopFeed<T> {
+    pub request: Box<RequestBuilder>,
+    pub data: Box<T>,
+    pub res_tx: ResultLocation,
+}
+
+#[derive(Debug)]
+struct SlaveWorkerFeed<T> {
+    pub request: Box<RequestBuilder>,
+    pub data: Box<T>,
+    pub res_tx: ResultLocation,
+}
+
+#[derive(Debug, Clone)]
+enum ResultLocation {
+    Somewhere(usize),
+    None,
+}
+
+#[derive(Debug)]
+enum LoopCommand<T> {
+    Feed(LoopFeed<T>),
+    BatchFeed(LoopFeedBatch<T>),
+    RegisterResultLocation(Location<T>),
+    Full,  //LazyFull.
+    ForceFull,
+}
+
+#[derive(Debug)]
+enum SlaveCommand<T> {
+    Feed(SlaveWorkerFeed<T>),
+    RegisterResultLocation(Sender<(Box<T>, Result<(), String>)>),
+    Full, // lazy graceful shutdown.
+    ForceFull,
+}
+
+#[derive(Debug, Clone)]
+struct Location<T> {
+    pub synchronize: Sender<usize>,
+    pub somewhere: Sender<(Box<T>, Result<(), String>)>,
+}
+
+async fn job<T>(feed: SlaveWorkerFeed<T>, client: Client, locs: usize, ctx: usize)
+where
+    T: ChainhookOccurrence + Clone + Debug
+{
+    let ctx = unsafe {
+        &*(ctx as *const Context)
+    };
+    let SlaveWorkerFeed { request, res_tx, data } = feed;
+
+    let request = request.build();
+
+    if let Err(e) = request {
+        let msg =
+        format!("Unable to parse url {}", e);
+        ctx.try_log(|logger| slog::warn!(logger, "{}", msg));
+        return
+    }
+
+    let req = request.unwrap();
+    let res = send_request(RequestBuilder::from_parts(client, req), 3, 1, ctx).await;
+
+    match res_tx {
+        ResultLocation::Somewhere(here) => {
+            let locs = unsafe {
+                &*(locs as *const Vec<Sender<(Box<T>, Result<(), String>)>>)
+            };
+            locs[here].send((data, res));
+        },
+
+        ResultLocation::None => {},
+    }
+}
+
+#[derive(Clone)]
+pub struct Dispatcher<T> 
+where
+    T: ChainhookOccurrence + Clone + Debug + Sync + Send + 'static
+{
+    inner: DispatcherInner<T>,
+}
+
+#[derive(Debug, Clone)]
+enum Flavor {
+    SingleThreaded,
+    MultiThreaded(u16),
+}
+
+struct DispatcherInner<T> {
+    flavor: Flavor,
+    is_running: Arc<AtomicI8>,
+    queue: Queue<T>,
+    rx: Arc<Mutex<Receiver<T>>>, // mutex is not necessary
+    handle: Arc<Mutex<Option<JoinHandle<ReceiverType<T>>>>>, // beacause of atomic but just in case
+    response: Option<Response<T>>,
+    ctx: Context,
+}
+
+#[derive(Debug, Clone)]
+enum Queue<T> {
+    SingleThreaded(SingleThreadedQueue<T>),
+    MultiThreaded(MultiThreadedQueue<T>),
+}
+
+#[derive(Debug)]
+enum Receiver<T> {
+    Available(ReceiverType<T>),
+    Taken,
+}
+
+impl<T> Default for Receiver<T> 
+where
+    T: ChainhookOccurrence + Clone + Debug + Sync + Send + 'static
+{
+    fn default() -> Self {
+        Self::Taken
+    }
+}
+
+#[derive(Debug)]
+enum ReceiverType<T> {
+    SingleThreaded(UnboundedReceiver<LoopCommand<T>>),
+    MultiThreaded(crossbeam_channel::Receiver<LoopCommand<T>>),
+}
+
+#[derive(Debug)]
+struct Response<T> {
+    rx: crossbeam_channel::Receiver<(Box<T>, Result<(), String>)>,
+    token_id: usize,
+}
+
+#[derive(Debug, Clone)]
+struct SingleThreadedQueue<T> {
+    tx: tokio::sync::mpsc::UnboundedSender<LoopCommand<T>>,
+}
+
+#[derive(Debug, Clone)]
+struct MultiThreadedQueue<T> {
+    tx: crossbeam_channel::Sender<LoopCommand<T>>,
+}
+
+impl<T> Clone for DispatcherInner<T> 
+where
+    T: ChainhookOccurrence + Clone + Debug + Sync + Send + 'static
+{
+    fn clone(&self) -> Self {
+        Self { 
+            flavor: self.flavor.clone(), 
+            is_running: Arc::clone(&self.is_running), 
+            queue: self.queue.clone(),
+            rx: Arc::clone(&self.rx), 
+            handle: Arc::clone(&self.handle), 
+            response: None, 
+            ctx: self.ctx.clone(),
+        }
+    }
+}
+
+impl<T> Dispatcher<T>
+where
+    T: ChainhookOccurrence + Clone + Debug + Sync + Send + 'static
+{
+    pub fn new_single_threaded(ctx: &Context) -> Self {
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+
+        let inner = DispatcherInner { 
+            flavor: Flavor::SingleThreaded, 
+            is_running: Arc::new(AtomicI8::new(0)), 
+            queue: Queue::SingleThreaded(SingleThreadedQueue { tx }),
+            rx: Arc::new(Mutex::new(Receiver::Available(ReceiverType::SingleThreaded(rx)))),
+            handle: Arc::new(Mutex::new(Option::None)),
+            response: None, 
+            ctx: ctx.clone(), 
+        };
+
+        Dispatcher { inner }
+    }
+
+    pub fn new_multi_threaded(num_of_threads: u16, ctx: &Context) -> Self {
+        if num_of_threads < 2 {
+            return Self::new_single_threaded(ctx)
+        }
+
+        let (tx, rx) = crossbeam_channel::unbounded();
+
+        let inner = DispatcherInner {
+            flavor: Flavor::MultiThreaded(num_of_threads),
+            is_running: Arc::new(AtomicI8::new(0)), 
+            queue: Queue::MultiThreaded(MultiThreadedQueue { tx }),
+            rx: Arc::new(Mutex::new(Receiver::Available(ReceiverType::MultiThreaded(rx)))),
+            handle: Arc::new(Mutex::new(Option::None)), 
+            response: None, 
+            ctx: ctx.clone(),
+        };
+
+        Dispatcher { inner }
+    }
+
+    pub fn start(&mut self) {
+        self.inner.start();
+    }
+
+    pub fn register_result_location(&mut self) {
+        self.inner.register_result_location();
+    }
+
+    pub fn send(&self, request: RequestBuilder, data: T) {
+        self.inner.send(request, data);
+    }
+
+    pub fn send_batch(&self, requests: Vec<(Box<RequestBuilder>, Box<T>)>) {
+        self.inner.send_batch(requests);
+    }
+
+    pub fn recv(&self) -> Result<(Box<T>, Result<(), String>), ()> {
+        self.inner.recv()
+    }
+
+    pub fn try_recv(&self) -> Result<(Box<T>, Result<(), String>), ()> {
+        self.inner.try_recv()
+    }
+
+    pub fn try_iter(&self) -> Result<Vec<(Box<T>, Result<(), String>)>, ()> {
+        self.inner.try_iter()
+    }
+
+    pub fn graceful_shutdown(&mut self) {
+        self.inner.graceful_shutdown();
+    }
+
+    pub fn force_shutdown(&mut self) {
+        self.inner.force_shutdown();
+    }
+}
+
+impl<T> DispatcherInner<T>
+where
+    T: ChainhookOccurrence + Clone + Debug + Sync + Send + 'static
+{
+    fn start(&mut self) {
+        match self.is_running.compare_exchange(0, -1, Ordering::Acquire, Ordering::Relaxed) {
+            Err(x) => {
+                match x {
+                    1 => {
+                        let msg = format!("unable to satrt the dispatcher. An instance associated with this object is already running.");
+                        return self.ctx.try_log(|logger| slog::info!(logger, "{}", msg))
+                    },
+
+                    -1 => {
+                        let msg = format!("try to start again.");
+                        return self.ctx.try_log(|logger| slog::info!(logger, "{}", msg))
+                    },
+
+                    _ => {}
+                }
+            },
+
+            Ok(_x) => {},
+        }
+
+        let moved_ctx = self.ctx.clone();
+
+        match &self.flavor {
+            Flavor::SingleThreaded => {
+                let rx = std::mem::take(&mut *self.rx.lock().unwrap());
+
+                if let Receiver::Available(ReceiverType::SingleThreaded(rx)) = rx {
+                    let handle = thread::spawn(|| single_threaded_loop(rx, moved_ctx));
+                    *self.handle.lock().unwrap() = Some(handle);   
+                }
+            },
+
+            Flavor::MultiThreaded(num_threads) => {
+                let pool_size = *num_threads;
+                
+                let rx = std::mem::take(&mut *self.rx.lock().unwrap());
+
+                if let Receiver::Available(ReceiverType::MultiThreaded(rx)) = rx {
+                    let handle = thread::spawn(move || multi_threaded_loop(rx, pool_size, &moved_ctx));
+                    *self.handle.lock().unwrap() = Some(handle);
+                }
+            },
+        }
+
+        self.is_running.store(1, Ordering::Release);
+    }
+
+    fn register_result_location(&mut self) {
+        if 1 != self.is_running.load(Ordering::Relaxed) {
+            let msg = format!("No instance of the dispatcher is running.");
+            return self.ctx.try_log(|logger| slog::info!(logger, "{}", msg))
+        }
+
+        if let Some(_) = &self.response {
+            let msg = format!("this instance is already registered.");
+            return self.ctx.try_log(|logger| slog::info!(logger, "{}", msg))
+        }
+
+        match &self.queue {
+            Queue::SingleThreaded(SingleThreadedQueue { tx }) => {
+                let (syn_tx, syn_rx) = unbounded();
+                let (res_tx, res_rx) = unbounded();
+                let loc = Location { synchronize: syn_tx, somewhere: res_tx};
+
+                tx.send(LoopCommand::RegisterResultLocation(loc));
+
+                let token_id = syn_rx.recv().unwrap();
+
+                self.response = Some(Response { rx: res_rx, token_id });
+            },
+
+            Queue::MultiThreaded(MultiThreadedQueue { tx }) => {
+                let (syn_tx, syn_rx) = unbounded();
+                let (res_tx, res_rx) = unbounded();
+                let loc = Location { synchronize: syn_tx, somewhere: res_tx};
+
+                tx.send(LoopCommand::RegisterResultLocation(loc));
+
+                let token_id = syn_rx.recv().unwrap();
+
+                self.response = Some(Response { rx: res_rx, token_id });
+            },
+        }
+    }
+
+    fn send(&self, request: RequestBuilder, data: T) {
+        let request = Box::new(request);
+        let data = Box::new(data);
+
+        let res_tx = match &self.response {
+            Some(res) => {
+                ResultLocation::Somewhere(res.token_id)
+            },
+
+            None => ResultLocation::None,
+        };
+
+        let msg = LoopCommand::Feed(LoopFeed { request, data, res_tx });
+
+        match &self.queue {
+            Queue::SingleThreaded(SingleThreadedQueue { tx }) => {
+                tx.send(msg);
+            },
+
+            Queue::MultiThreaded(MultiThreadedQueue { tx }) => {
+                tx.send(msg);
+            },
+        }
+    }
+
+    fn send_batch(&self, requests: Vec<(Box<RequestBuilder>, Box<T>)>) {
+        let res_tx = match &self.response {
+            Some(res) => {
+                ResultLocation::Somewhere(res.token_id)
+            },
+
+            None => ResultLocation::None,
+        };
+
+        let msg = LoopCommand::BatchFeed(LoopFeedBatch { requests, res_tx });
+
+        match &self.queue {
+            Queue::SingleThreaded(SingleThreadedQueue { tx }) => {
+                tx.send(msg);
+            },
+
+            Queue::MultiThreaded(MultiThreadedQueue { tx }) => {
+                tx.send(msg);
+            },
+        }
+    }
+
+    fn recv(&self) -> Result<(Box<T>, Result<(), String>), ()> {
+        if 1 != self.is_running.load(Ordering::Relaxed) {
+            let msg = format!("No instance of the dispatcher is running.");
+            self.ctx.try_log(|logger| slog::info!(logger, "{}", msg));
+            return Err(())
+        }
+
+        match &self.response {
+            Some(res) => {
+                match res.rx.recv() {
+                    Ok(val) => {
+                        Ok(val)
+                    },
+
+                    Err(e) => {
+                        self.ctx.try_log(|logger| {
+                            slog::crit!(logger, "Error: broken channel {}", e.to_string())
+                        });
+                        Err(())
+                    },
+                }
+            },
+
+            None => {
+                let msg = format!("This instance of the dispatcher is not yet registered to recieve responses.");
+                self.ctx.try_log(|logger| slog::info!(logger, "{}", msg));
+                return Err(())
+            },
+        }
+    }
+
+    fn try_recv(&self) -> Result<(Box<T>, Result<(), String>), ()> {
+        if 1 != self.is_running.load(Ordering::Relaxed) {
+            let msg = format!("No instance of the dispatcher is running.");
+            self.ctx.try_log(|logger| slog::info!(logger, "{}", msg));
+            return Err(())
+        }
+
+        match &self.response {
+            Some(res) => {
+                match res.rx.try_recv() {
+                    Ok(val) => {
+                        return Ok(val)
+                    },
+
+                    Err(e) => {
+                        self.ctx.try_log(|logger| {
+                            slog::warn!(logger, "Error: {}", e.to_string())
+                        });
+                        return Err(())
+                    },
+                }
+            },
+
+            None => {
+                let msg = format!("This instance of the dispatcher is not yet registered to recieve responses.");
+                self.ctx.try_log(|logger| slog::info!(logger, "{}", msg));
+                return Err(())
+            },
+        }
+    }
+
+    fn try_iter(&self) -> Result<Vec<(Box<T>, Result<(), String>)>, ()> {
+        if 1 != self.is_running.load(Ordering::Relaxed) {
+            let msg = format!("No instance of the dispatcher is running.");
+            self.ctx.try_log(|logger| slog::info!(logger, "{}", msg));
+            return Err(())
+        }
+
+        match &self.response {
+            Some(res) => {
+                let iterator = res.rx.try_iter().collect::<Vec<_>>();
+                return Ok(iterator)
+            },
+
+            None => {
+                let msg = format!("This instance of the dispatcher is not yet registered to recieve responses.");
+                self.ctx.try_log(|logger| slog::info!(logger, "{}", msg));
+                return Err(())
+            },
+        }
+    }
+
+    fn graceful_shutdown(&mut self) {
+        match self.is_running.compare_exchange(1, -1, Ordering::Acquire, Ordering::Relaxed) {
+            Err(x) => {
+                match x {
+                    0 => {
+                        let msg = format!("No instance of the dispatcher is running.");
+                        return self.ctx.try_log(|logger| slog::info!(logger, "{}", msg))
+                    },
+
+                    -1 => {
+                        let msg = format!("try to shutdown again.");
+                        return self.ctx.try_log(|logger| slog::info!(logger, "{}", msg))
+                    },
+
+                    _ => {},    
+                }
+            },
+
+            Ok(_x) => {},
+        }
+
+        let msg: LoopCommand<T> = LoopCommand::Full;
+
+        match &self.queue {
+            Queue::SingleThreaded(SingleThreadedQueue { tx }) => {
+                tx.send(msg);
+                
+                let handle = self.handle.lock().unwrap().take();
+
+                let rx = handle.unwrap().join().unwrap();
+
+                *self.rx.lock().unwrap() = Receiver::Available(rx);
+            },
+
+            Queue::MultiThreaded(MultiThreadedQueue { tx }) => {
+                tx.send(msg);
+
+                let handle = self.handle.lock().unwrap().take();
+
+                let rx = handle.unwrap().join().unwrap();
+
+                *self.rx.lock().unwrap() = Receiver::Available(rx);
+            },
+        }
+
+        self.is_running.store(0, Ordering::Release);
+    }
+
+    fn force_shutdown(&mut self) {
+        match self.is_running.compare_exchange(1, -1, Ordering::Acquire, Ordering::Relaxed) {
+            Err(x) => {
+                match x {
+                    0 => {
+                        let msg = format!("No instance of the dispatcher is running.");
+                        return self.ctx.try_log(|logger| slog::info!(logger, "{}", msg))
+                    },
+
+                    -1 => {
+                        let msg = format!("try to shutdown again.");
+                        return self.ctx.try_log(|logger| slog::info!(logger, "{}", msg))
+                    }
+
+                    _ => {},
+                }
+            },
+
+            Ok(_x) => {},
+        }
+
+        let msg: LoopCommand<T> = LoopCommand::ForceFull;
+
+        match &self.queue {
+            Queue::SingleThreaded(SingleThreadedQueue { tx }) => {
+                tx.send(msg);
+                
+                let handle = self.handle.lock().unwrap().take();
+
+                let rx = handle.unwrap().join().unwrap();
+
+                *self.rx.lock().unwrap() = Receiver::Available(rx);
+            },
+
+            Queue::MultiThreaded(MultiThreadedQueue { tx }) => {
+                tx.send(msg);
+
+                let handle = self.handle.lock().unwrap().take();
+
+                let rx = handle.unwrap().join().unwrap();
+
+                *self.rx.lock().unwrap() = Receiver::Available(rx);
+            },
+        }
+
+        self.is_running.store(0, Ordering::Release);
+    }
+}
+
+impl<T> Drop for Dispatcher<T>
+where
+    T: ChainhookOccurrence + Clone + Debug + Sync + Send + 'static
+{
+    fn drop(&mut self) {
+        if 1 == Arc::strong_count(&self.inner.is_running) {
+            if 1 != self.inner.is_running.load(Ordering::Relaxed) {
+                return
+            }
+
+            self.force_shutdown();
+        }
+    }
+}

--- a/components/chainhook-sdk/src/dispatcher/multi_threaded.rs
+++ b/components/chainhook-sdk/src/dispatcher/multi_threaded.rs
@@ -1,0 +1,140 @@
+use std::{fmt::Debug, thread, time::Duration};
+
+use crossbeam_channel::Receiver;
+use reqwest::Client;
+use tokio::{runtime, sync::mpsc::{unbounded_channel, UnboundedReceiver}, task::JoinSet};
+
+use crate::utils::Context;
+
+use super::{job, ChainhookOccurrence, Location, LoopCommand, LoopFeed, LoopFeedBatch, ReceiverType, SlaveCommand, SlaveWorkerFeed};
+
+pub fn multi_threaded_loop<T>(
+    rx: Receiver<LoopCommand<T>>, 
+    pool_size: u16, 
+    ctx: &Context
+) -> ReceiverType<T>
+where
+    T: ChainhookOccurrence + Clone + Debug + Sync + Send + 'static
+{
+    let mut slave_workers = Vec::new();
+    let mut worker_queues = Vec::new();
+    let mut response_locations = Vec::new();
+
+    for _ in 0..pool_size {
+        let moved_ctx = ctx.clone();
+        let (tx, rx) = unbounded_channel();
+        let slave_worker = thread::spawn(move || slave_worker(rx, moved_ctx));
+        slave_workers.push(slave_worker);
+        worker_queues.push(tx);
+    }
+
+    let mut i = 0;
+    'outer: loop {
+        i = i % pool_size;
+        let mut master_queue = Vec::new();
+        let inbounds = rx.try_iter(); 
+        for inbound in inbounds {
+            match inbound {
+                LoopCommand::Feed(feed) => {
+                    let LoopFeed { request, res_tx, data } = feed;
+                    master_queue.push(SlaveCommand::Feed(SlaveWorkerFeed{ request, res_tx, data }));
+                },
+
+                LoopCommand::BatchFeed(feed_batch) => {
+                    let LoopFeedBatch { requests, res_tx } = feed_batch;
+                    for (request, data) in requests {
+                        master_queue.push(SlaveCommand::Feed(SlaveWorkerFeed { request, res_tx: res_tx.clone(), data }));
+                    }
+                },
+
+                LoopCommand::RegisterResultLocation(loc) => {
+                    let Location { 
+                        synchronize, 
+                        somewhere 
+                    } = loc;
+
+                    let x = response_locations.len();
+                    synchronize.send(x);
+
+                    for sender in &worker_queues {
+                        sender.send(SlaveCommand::RegisterResultLocation(somewhere.clone()));
+                    }
+
+                    response_locations.push(somewhere);
+                },
+
+                LoopCommand::Full => {
+                    for _ in 0..pool_size {
+                        master_queue.push(SlaveCommand::Full);
+                    }
+
+                    for slave_work in master_queue {
+                        worker_queues[(i % pool_size) as usize].send(slave_work);
+                        i = i + 1;
+                    }
+
+                    break 'outer;
+                },
+
+                LoopCommand::ForceFull => {
+                    //maybe a atomic variable? can be used to force terminate the slave threads faster.
+                    for sender in &worker_queues {
+                        sender.send(SlaveCommand::ForceFull);
+                    }
+
+                    break 'outer;
+                },
+            }
+        }
+
+        for slave_work in master_queue {
+            worker_queues[(i % pool_size) as usize].send(slave_work);
+            i = i + 1;
+        }
+
+        thread::sleep(Duration::from_millis(50));
+    }
+
+    for slave in slave_workers {
+        slave.join();
+    }
+
+    ReceiverType::MultiThreaded(rx)
+}
+
+fn slave_worker<T>(mut rx: UnboundedReceiver<SlaveCommand<T>>, ctx: Context)
+where
+    T: ChainhookOccurrence + Clone + Debug + Sync + Send + 'static
+{
+    let rt = runtime::Builder::new_current_thread().enable_all().build().unwrap();
+    let client = Client::new();
+    let new_ctx = &ctx as *const _ as usize;
+    let mut result_locations = Vec::new();
+    let locs = &result_locations as *const _ as usize;
+    let mut set = JoinSet::new();
+
+    rt.block_on( async {
+            while let Some(cmd) = rx.recv().await {
+                match cmd {
+                    SlaveCommand::Feed(feed) => {
+                        let moved_ctx = new_ctx;
+                        let moved_client = client.clone();
+                        let moved_locs = locs;                        
+                        set.spawn(job(feed, moved_client, moved_locs, moved_ctx));
+                    },
+
+                    SlaveCommand::RegisterResultLocation(here) => {
+                        result_locations.push(here)
+                    },
+
+                    SlaveCommand::Full => {
+                        while set.join_next().await.is_some() {}
+                        break;
+                    },
+
+                    SlaveCommand::ForceFull => break,
+                }
+            }
+
+    });
+}

--- a/components/chainhook-sdk/src/dispatcher/single_threaded.rs
+++ b/components/chainhook-sdk/src/dispatcher/single_threaded.rs
@@ -1,0 +1,72 @@
+use std::fmt::Debug;
+
+use reqwest::Client;
+use tokio::{runtime::Builder, sync::mpsc::UnboundedReceiver, task::JoinSet};
+
+use crate::utils::Context;
+
+use super::{job, ChainhookOccurrence, Location, LoopCommand, LoopFeed, LoopFeedBatch, ReceiverType, SlaveWorkerFeed};
+
+pub fn single_threaded_loop<T>(mut rx: UnboundedReceiver<LoopCommand<T>>, ctx: Context) -> ReceiverType<T>
+where
+    T: ChainhookOccurrence + Clone + Debug + Sync + Send + 'static
+{
+    let rt = Builder::new_current_thread().enable_all().build().unwrap();
+    let mut set = JoinSet::new();
+    let client = Client::new();
+    let mut response_locations = Vec::new();
+    let locs = &response_locations as *const _ as usize;
+    let new_ctx = &ctx as *const _ as usize;
+
+    rt.block_on( async {
+        while let Some(cmd) = rx.recv().await {
+            match cmd {
+                LoopCommand::Feed(feed) => {
+                    let LoopFeed { request, data, res_tx } = feed;
+                    let feed = SlaveWorkerFeed { request, data, res_tx };
+
+                    let moved_ctx = new_ctx;
+                    let moved_client = client.clone();
+                    let moved_locs = locs;                
+
+                    set.spawn(job(feed, moved_client, moved_locs, moved_ctx));
+                },
+
+                LoopCommand::BatchFeed(feed_batch) => {
+                    let LoopFeedBatch { requests, res_tx } = feed_batch;
+
+                    for (request, data) in requests {
+                        let feed = SlaveWorkerFeed { request, data, res_tx:res_tx.clone() };
+
+                        let moved_ctx = new_ctx;
+                        let moved_client = client.clone();
+                        let moved_locs = locs;       
+
+                        set.spawn(job(feed, moved_client, moved_locs, moved_ctx));
+                    }
+                },
+
+                LoopCommand::RegisterResultLocation(loc) => {
+                    let Location { 
+                        synchronize, 
+                        somewhere 
+                    } = loc;
+
+                    let x = response_locations.len();
+                    synchronize.send(x);
+
+                    response_locations.push(somewhere);
+                },
+
+                LoopCommand::Full => {
+                    while set.join_next().await.is_some() {}
+                    break;
+                },
+
+                LoopCommand::ForceFull => break,
+            }
+        }
+    });
+
+    ReceiverType::SingleThreaded(rx)
+}

--- a/components/chainhook-sdk/src/lib.rs
+++ b/components/chainhook-sdk/src/lib.rs
@@ -22,6 +22,7 @@ pub use bitcoincore_rpc::bitcoin;
 pub use chainhook_types as types;
 
 pub mod chainhooks;
+pub mod dispatcher;
 pub mod indexer;
 pub mod monitoring;
 pub mod observer;

--- a/components/chainhook-sdk/src/utils/mod.rs
+++ b/components/chainhook-sdk/src/utils/mod.rs
@@ -187,7 +187,7 @@ pub async fn send_request(
             ctx.try_log(|logger| slog::warn!(logger, "{}", msg));
             return Err(msg);
         }
-        std::thread::sleep(std::time::Duration::from_secs(attempts_interval_sec.into()));
+        tokio::time::sleep(std::time::Duration::from_secs(attempts_interval_sec.into())).await;
     }
 }
 


### PR DESCRIPTION
addresses #406 

Since chainhooks is intended to be used as a service, which is heavy in both computational and io/network related processes, and both of these processes do not overlap at all at either hardware or software level. Hence performing both sequentially is quite a bottleneck for chainhook to reach its full potential.

This pr helps to be able to use chainhooks at scale and it does this in two main ways:

- Decoupling the cpu-bound compute tasks from the io-bound/network related tasks.

- The io-bound tasks are further processed asynchronously using tokio ( I don't know why tokio was not getting utilized this way before) rather than sequentially like before.

This will make chainhooks capable to process thousands of more requests at the same time. 
In theory, this could bring speed-ups of orders of magnitude greater than before.

The heart of this feature is a dispatcher module with two flavors: a single threaded/light weight one and a multi threaded one.
The dispatcher module is free to be customized as per individual use cases as it offers great flexibility and adaptability for different kinds of workloads at any scale desired.

The single-threaded one should suffice most of the use cases. This mode can either be use centrally in the service or individually like this:

![single](https://github.com/user-attachments/assets/3a17e6d8-6192-4f18-8577-f6b882d58478)
 
depending on the various case-by-case basis like for eg. if service is more bitcoin runloop heavy or more observer heavy depending on the probable range of blocks, that part can be made to possess its own instance of dispatcher or given more resources to. While the less heavy/light parts can be given less resources or can share a instance.

The multi threaded one is more intended to be used as a central entity processing and dispatching requests from different parts of the codebase like so:

![multi](https://github.com/user-attachments/assets/79ea1852-fe1b-4068-8346-4ade44087c31)

the number of threads can be configured as desired by the workload.

Finally, even a simple central single threaded dispatcher is leagues better than previous implementations. Providing almost similar performance as above with minimal resources.

As for the integration, I have provided a reference one in the second commit.
I was in a haste, so this is just for the reference for now as I had quite different ideas for the integration part and I believe this could have been approached and integrated in a much better way.