### PR TITLE
fix: read stacks-core http event POST payloads for ignored events

### DIFF
--- a/components/chainhook-cli/src/service/tests/observer_tests.rs
+++ b/components/chainhook-cli/src/service/tests/observer_tests.rs
@@ -170,8 +170,8 @@ async fn start_and_ping_event_observer(config: EventObserverConfig, ingestion_po
     .unwrap();
     await_observer_started(ingestion_port).await;
 }
-#[test_case("/drop_mempool_tx", Method::POST, None)]
-#[test_case("/attachments/new", Method::POST, None)]
+#[test_case("/drop_mempool_tx", Method::POST, Some(&json!({})))]
+#[test_case("/attachments/new", Method::POST, Some(&json!({})))]
 #[test_case("/mined_block", Method::POST, Some(&json!({})))]
 #[test_case("/mined_microblock", Method::POST, Some(&json!({})))]
 #[tokio::test]

--- a/components/chainhook-sdk/src/observer/http.rs
+++ b/components/chainhook-sdk/src/observer/http.rs
@@ -301,9 +301,9 @@ pub fn handle_new_mempool_tx(
     success_response()
 }
 
-#[post("/drop_mempool_tx", format = "application/json")]
-pub fn handle_drop_mempool_tx(ctx: &State<Context>) -> Json<JsonValue> {
-    ctx.try_log(|logger| slog::debug!(logger, "POST /drop_mempool_tx"));
+#[post("/drop_mempool_tx", format = "application/json", data = "<payload>")]
+pub fn handle_drop_mempool_tx(payload: Json<JsonValue>, ctx: &State<Context>) -> Json<JsonValue> {
+    ctx.try_log(|logger| slog::debug!(logger, "POST /drop_mempool_tx {:?}", payload));
     // TODO(lgalabru): use propagate mempool events
     Json(json!({
         "status": 200,
@@ -311,9 +311,9 @@ pub fn handle_drop_mempool_tx(ctx: &State<Context>) -> Json<JsonValue> {
     }))
 }
 
-#[post("/attachments/new", format = "application/json")]
-pub fn handle_new_attachement(ctx: &State<Context>) -> Json<JsonValue> {
-    ctx.try_log(|logger| slog::debug!(logger, "POST /attachments/new"));
+#[post("/attachments/new", format = "application/json", data = "<payload>")]
+pub fn handle_new_attachement(payload: Json<JsonValue>, ctx: &State<Context>) -> Json<JsonValue> {
+    ctx.try_log(|logger| slog::debug!(logger, "POST /attachments/new {:?}", payload));
     Json(json!({
         "status": 200,
         "result": "Ok",


### PR DESCRIPTION
Workaround for bug in stacks-core event emitter http code. Regression in stacks-core where http requests must now have their POST body read before closing the connection.

```
chainhook-1    | {"msg":"POST /drop_mempool_tx","level":"DEBUG","ts":"2024-10-30T10:41:34.030361652Z"}
stacks-node-1  | WARN [1730284894.031170] [testnet/stacks-node/src/event_dispatcher.rs:496] [relayer-http://0.0.0.0:20443/] Event dispatcher: connection or request failed to chainhook:20455 - Custom { kind: Other, error: "Failed to send 8192 bytes: \"Failed to send socket data\"" }, backoff: 158.191s, attempts: 10
```


Chainhook ignored some events by returning a 200 http response and closing the connection after reading the http request headers, and ignoring the request body.