### PR TITLE
feat: callback to intercept and modify predicates before re-registration

### DIFF
--- a/components/client/typescript/src/index.ts
+++ b/components/client/typescript/src/index.ts
@@ -6,6 +6,7 @@ import { Static, Type } from '@fastify/type-provider-typebox';
 import { BitcoinIfThisOptionsSchema, BitcoinIfThisSchema } from './schemas/bitcoin/if_this';
 import { StacksIfThisOptionsSchema, StacksIfThisSchema } from './schemas/stacks/if_this';
 import { logger } from './util/logger';
+import { PredicateSchema } from './schemas/predicate';
 
 const EventObserverOptionsSchema = Type.Object({
   /** Event observer host name (usually '0.0.0.0') */
@@ -40,6 +41,9 @@ const EventObserverOptionsSchema = Type.Object({
    * up to date. If they become obsolete, we will attempt to re-register them.
    */
   predicate_health_check_interval_ms: Type.Optional(Type.Integer({ default: 5000 })),
+  predicate_re_register_callback: Type.Optional(
+    Type.Function([PredicateSchema], Type.Promise(PredicateSchema))
+  ),
 });
 /** Chainhook event observer configuration options */
 export type EventObserverOptions = Static<typeof EventObserverOptionsSchema>;

--- a/components/client/typescript/src/predicates.ts
+++ b/components/client/typescript/src/predicates.ts
@@ -146,10 +146,14 @@ async function registerPredicate(
         authorization_header: `Bearer ${observer.auth_token}`,
       },
     };
-    const newPredicate = pendingPredicate as Predicate;
+    let newPredicate = pendingPredicate as Predicate;
     newPredicate.uuid = randomUUID();
     if (newPredicate.networks.mainnet) newPredicate.networks.mainnet.then_that = thenThat;
     if (newPredicate.networks.testnet) newPredicate.networks.testnet.then_that = thenThat;
+
+    if (observer.predicate_re_register_callback) {
+      newPredicate = await observer.predicate_re_register_callback(newPredicate);
+    }
 
     const path = observer.node_type === 'chainhook' ? `/v1/chainhooks` : `/v1/observers`;
     await request(`${chainhook.base_url}${path}`, {

--- a/components/client/typescript/tests/predicates.test.ts
+++ b/components/client/typescript/tests/predicates.test.ts
@@ -83,7 +83,7 @@ describe('predicates', () => {
     await server.start([testPredicate], async () => {});
 
     expect(fs.existsSync(`${observer.predicate_disk_file_path}/predicate-test.json`)).toBe(true);
-    const disk = recallPersistedPredicatesFromDisk(observer.predicate_disk_file_path);
+    const disk = await recallPersistedPredicatesFromDisk(observer.predicate_disk_file_path);
     const storedPredicate = disk.get('test');
     expect(storedPredicate).not.toBeUndefined();
     expect(storedPredicate?.name).toBe(testPredicate.name);
@@ -102,8 +102,8 @@ describe('predicates', () => {
   });
 
   describe('pre-stored', () => {
-    beforeEach(() => {
-      savePredicateToDisk(observer.predicate_disk_file_path, {
+    beforeEach(async () => {
+      await savePredicateToDisk(observer.predicate_disk_file_path, {
         uuid: 'e2777d77-473a-4c1d-9012-152deb36bf4c',
         name: 'test',
         version: 1,
@@ -164,7 +164,7 @@ describe('predicates', () => {
 
       mockAgent.assertNoPendingInterceptors();
       expect(fs.existsSync(`${observer.predicate_disk_file_path}/predicate-test.json`)).toBe(true);
-      const disk = recallPersistedPredicatesFromDisk(observer.predicate_disk_file_path);
+      const disk = await recallPersistedPredicatesFromDisk(observer.predicate_disk_file_path);
       const storedPredicate = disk.get('test');
       // Should have a different uuid
       expect(storedPredicate?.uuid).not.toBe('e2777d77-473a-4c1d-9012-152deb36bf4c');


### PR DESCRIPTION
Closes https://github.com/hirosystems/chainhook/issues/674

* First commit adds an optional callback that clients can use to modify an inactive predicate before it is re-registered.
* Second commit fixes an issue where the the `setInterval` could result in overlapping healthcheck code running if something like the callback (which could be waiting on a postgres connection, for example) take a long time.