### PR TITLE
fix: ts client missing matches_regex option for print_event

### DIFF
--- a/components/client/typescript/src/schemas/stacks/if_this.ts
+++ b/components/client/typescript/src/schemas/stacks/if_this.ts
@@ -53,6 +53,13 @@ export const StacksIfThisPrintEventSchema = Type.Object({
 });
 export type StacksIfThisPrintEvent = Static<typeof StacksIfThisPrintEventSchema>;
 
+export const StacksIfThisPrintEventRegexSchema = Type.Object({
+  scope: Type.Literal('print_event'),
+  contract_identifier: Type.String(),
+  matches_regex: Type.String(),
+});
+export type StacksIfThisPrintEventRegex = Static<typeof StacksIfThisPrintEventRegexSchema>;
+
 export const StacksIfThisContractCallSchema = Type.Object({
   scope: Type.Literal('contract_call'),
   contract_identifier: Type.String(),
@@ -90,6 +97,7 @@ export const StacksIfThisSchema = Type.Union([
   StacksIfThisNftEventSchema,
   StacksIfThisStxEventSchema,
   StacksIfThisPrintEventSchema,
+  StacksIfThisPrintEventRegexSchema,
   StacksIfThisContractCallSchema,
   StacksIfThisContractDeploymentSchema,
   StacksIfThisContractDeploymentTraitSchema,


### PR DESCRIPTION
### Description

This prs add the missing `matches_regex` option for the `print_event` predicate that is missing in the client SDK. 

#### Breaking change?

No

### Checklist

- [ ] All tests pass
- [ ] Tests added in this PR (if applicable)

