### PR TITLE
chore: clean dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,15 +110,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
-name = "array-init"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23589ecb866b460d3a0f1278834750268c607e8e28a1b982c907219f3178cd72"
-dependencies = [
- "nodrop",
-]
-
-[[package]]
 name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -456,7 +447,7 @@ version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
 dependencies = [
- "smallvec 1.13.2",
+ "smallvec",
  "target-lexicon",
 ]
 
@@ -524,28 +515,21 @@ dependencies = [
  "chainhook-types",
  "clarity",
  "crossbeam-channel",
- "dashmap",
- "futures",
- "fxhash",
  "hex",
  "hiro-system-kit",
  "hyper 0.14.27",
  "lazy_static",
  "miniscript",
  "prometheus",
- "rand",
  "regex",
  "reqwest",
  "rocket",
  "schemars",
  "serde",
- "serde-hex",
  "serde_derive",
  "serde_json",
  "stacks-codec",
  "test-case",
- "threadpool",
- "tokio",
  "zmq",
 ]
 
@@ -1337,15 +1321,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "generator"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1662,7 +1637,7 @@ dependencies = [
  "httparse",
  "itoa",
  "pin-project-lite",
- "smallvec 1.13.2",
+ "smallvec",
  "tokio",
  "want",
 ]
@@ -1915,7 +1890,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -2021,12 +1996,6 @@ checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata 0.1.10",
 ]
-
-[[package]]
-name = "maybe-uninit"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memchr"
@@ -2140,12 +2109,6 @@ dependencies = [
  "cfg_aliases",
  "libc",
 ]
-
-[[package]]
-name = "nodrop"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
 name = "nom"
@@ -2309,7 +2272,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "smallvec 1.13.2",
+ "smallvec",
  "windows-targets 0.52.6",
 ]
 
@@ -2548,15 +2511,8 @@ dependencies = [
  "lazy_static",
  "memchr",
  "parking_lot",
- "protobuf",
  "thiserror",
 ]
-
-[[package]]
-name = "protobuf"
-version = "2.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "psm"
@@ -2931,7 +2887,7 @@ dependencies = [
  "pin-project-lite",
  "ref-cast",
  "serde",
- "smallvec 1.13.2",
+ "smallvec",
  "stable-pattern",
  "state",
  "time",
@@ -2987,7 +2943,7 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "serde_json",
- "smallvec 1.13.2",
+ "smallvec",
 ]
 
 [[package]]
@@ -3200,17 +3156,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5665e14a49a4ea1b91029ba7d3bca9f299e1f7cfa194388ccc20f14743e784f2"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde-hex"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca37e3e4d1b39afd7ff11ee4e947efae85adfddf4841787bfa47c470e96dc26d"
-dependencies = [
- "array-init",
- "serde",
- "smallvec 0.6.14",
 ]
 
 [[package]]
@@ -3482,15 +3427,6 @@ dependencies = [
  "term",
  "thread_local",
  "time",
-]
-
-[[package]]
-name = "smallvec"
-version = "0.6.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97fcaeba89edba30f044a10c6a3cc39df9c3f17d7cd829dd1446cab35f890e0"
-dependencies = [
- "maybe-uninit",
 ]
 
 [[package]]
@@ -4107,7 +4043,7 @@ dependencies = [
  "once_cell",
  "regex",
  "sharded-slab",
- "smallvec 1.13.2",
+ "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",

--- a/components/chainhook-sdk/Cargo.toml
+++ b/components/chainhook-sdk/Cargo.toml
@@ -10,7 +10,6 @@ edition = "2021"
 [dependencies]
 serde = { version = "1", features = ["rc"] }
 serde_json = { version = "1", features = ["arbitrary_precision"] }
-serde-hex = "0.1.0"
 serde_derive = "1"
 stacks-codec = "2.4.1"
 clarity = { git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-develop", package = "clarity", default-features = false, features = [
@@ -27,22 +26,16 @@ reqwest = { version = "0.12", default-features = false, features = [
     "json",
     "rustls-tls",
 ] }
-tokio = { version = "1.38.1", features = ["full"] }
 base58 = "0.2.0"
 schemars = { version = "0.8.16", git = "https://github.com/hirosystems/schemars.git", branch = "feat-chainhook-fixes" }
 crossbeam-channel = "0.5.6"
-futures = "0.3.21"
 hyper = { version = "=0.14.27", features = ["http1", "client"] }
 hex = "0.4.3"
-threadpool = "1.8.1"
-rand = "0.8.5"
 zmq = { version = "0.10.0", optional = true }
-dashmap = "5.4.0"
-fxhash = "0.2.1"
 lazy_static = "1.4.0"
 regex = "1.9.3"
 miniscript = "11.0.0"
-prometheus = "0.13.3"
+prometheus = { version = "0.13.3", default-features = false }
 
 chainhook-types = { path = "../chainhook-types-rs" }
 

--- a/components/chainhook-sdk/src/lib.rs
+++ b/components/chainhook-sdk/src/lib.rs
@@ -15,8 +15,6 @@ extern crate lazy_static;
 
 pub extern crate bitcoincore_rpc;
 pub extern crate bitcoincore_rpc_json;
-pub extern crate dashmap;
-pub extern crate fxhash;
 
 pub use bitcoincore_rpc::bitcoin;
 pub use chainhook_types as types;

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.80.1"
+channel = "stable"


### PR DESCRIPTION
### Description

Remove some dependencies.
Mostly motivated by `prometheus` having an old version of `protobuf` in default features

Also updating the toolchain. I don't see any reason not to use the stable. (and 0.80 wasn't compiling)