### PR TITLE
chore: upgrade clarinet dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3259,8 +3259,8 @@ dependencies = [
 
 [[package]]
 name = "stacks-codec"
-version = "2.15.2"
-source = "git+https://github.com/hirosystems/clarinet.git?rev=d5e3599d6f541fd82f3bc94bfc81211419b9938d#d5e3599d6f541fd82f3bc94bfc81211419b9938d"
+version = "2.16.0"
+source = "git+https://github.com/hirosystems/clarinet.git?rev=036304286cdfede81cb78f66db2b9af9d24254a7#036304286cdfede81cb78f66db2b9af9d24254a7"
 dependencies = [
  "clarity",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1334,15 +1334,6 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
@@ -1756,7 +1747,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3259,8 +3250,8 @@ dependencies = [
 
 [[package]]
 name = "stacks-codec"
-version = "2.16.0"
-source = "git+https://github.com/hirosystems/clarinet.git?rev=036304286cdfede81cb78f66db2b9af9d24254a7#036304286cdfede81cb78f66db2b9af9d24254a7"
+version = "3.2.0"
+source = "git+https://github.com/hirosystems/clarinet.git?rev=116137316023ae912848a1ee1845fed30b306fdc#116137316023ae912848a1ee1845fed30b306fdc"
 dependencies = [
  "clarity",
  "serde",
@@ -3314,24 +3305,24 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
-version = "0.23.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cae14b91c7d11c9a851d3fbc80a963198998c2a64eec840477fa92d8ce9b70bb"
+checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.23.1"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb0dc7ee9c15cea6199cde9a127fa16a4c5819af85395457ad72d68edc85a38"
+checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
 dependencies = [
- "heck 0.3.3",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 1.0.109",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3827,12 +3818,6 @@ checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,4 @@ default-members = ["components/chainhook-cli", "components/chainhook-sdk"]
 resolver = "2"
 
 [patch.crates-io]
-stacks-codec = { git = "https://github.com/hirosystems/clarinet.git", rev = "036304286cdfede81cb78f66db2b9af9d24254a7" }
+stacks-codec = { git = "https://github.com/hirosystems/clarinet.git", version = "3.2.0", rev = "116137316023ae912848a1ee1845fed30b306fdc" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,4 @@ default-members = ["components/chainhook-cli", "components/chainhook-sdk"]
 resolver = "2"
 
 [patch.crates-io]
-stacks-codec = { git = "https://github.com/hirosystems/clarinet.git", rev = "d5e3599d6f541fd82f3bc94bfc81211419b9938d" }
+stacks-codec = { git = "https://github.com/hirosystems/clarinet.git", rev = "036304286cdfede81cb78f66db2b9af9d24254a7" }

--- a/components/chainhook-sdk/Cargo.toml
+++ b/components/chainhook-sdk/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 serde = { version = "1", features = ["rc"] }
 serde_json = { version = "1", features = ["arbitrary_precision"] }
 serde_derive = "1"
-stacks-codec = "2.4.1"
+stacks-codec = "3.0.0"
 clarity = { git = "https://github.com/stacks-network/stacks-core.git", branch = "feat/clarity-wasm-develop", package = "clarity", default-features = false, features = ["log"] }
 hiro-system-kit = { version = "0.3.4", optional = true }
 rocket = { version = "=0.5.0", features = ["json"] }

--- a/components/chainhook-types-rs/Cargo.toml
+++ b/components/chainhook-types-rs/Cargo.toml
@@ -5,12 +5,10 @@ license = "MIT"
 version = "1.3.7"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 serde = "1"
 serde_json = "1"
 serde_derive = "1"
-strum = { version = "0.23.0", features = ["derive"] }
+strum = { version = "0.27.1", features = ["derive"] }
 schemars = { version = "0.8.16", git = "https://github.com/hirosystems/schemars.git", branch = "feat-chainhook-fixes" }
 hex = "0.4.3"


### PR DESCRIPTION
### Description

- upgrade stacks-codec to latest 3.2.0
- upgrade strum, in order to align the version used accross clarinet/chainhook/devnet-api