### PR TITLE
fix: read contract_interface from Stacks node block events

### DIFF
--- a/components/chainhook-cli/src/service/tests/helpers/mock_stacks_node.rs
+++ b/components/chainhook-cli/src/service/tests/helpers/mock_stacks_node.rs
@@ -124,7 +124,8 @@ fn create_stacks_new_transaction(index: u64) -> NewTransaction {
         raw_result: "0x0703".to_string(),
         raw_tx: "0x00000000010400e2cd0871da5bdd38c4d5569493dc3b14aac4e0a10000000000000019000000000000000000008373b16e4a6f9d87864c314dd77bbd8b27a2b1805e96ec5a6509e7e4f833cd6a7bdb2462c95f6968a867ab6b0e8f0a6498e600dbc46cfe9f84c79709da7b9637010200000000040000000000000000000000000000000000000000000000000000000000000000".to_string(),
         execution_cost: None,
-        contract_interface: None
+        contract_interface: None,
+        contract_abi: None,
     }
 }
 

--- a/components/chainhook-cli/src/service/tests/helpers/mock_stacks_node.rs
+++ b/components/chainhook-cli/src/service/tests/helpers/mock_stacks_node.rs
@@ -124,7 +124,7 @@ fn create_stacks_new_transaction(index: u64) -> NewTransaction {
         raw_result: "0x0703".to_string(),
         raw_tx: "0x00000000010400e2cd0871da5bdd38c4d5569493dc3b14aac4e0a10000000000000019000000000000000000008373b16e4a6f9d87864c314dd77bbd8b27a2b1805e96ec5a6509e7e4f833cd6a7bdb2462c95f6968a867ab6b0e8f0a6498e600dbc46cfe9f84c79709da7b9637010200000000040000000000000000000000000000000000000000000000000000000000000000".to_string(),
         execution_cost: None,
-        contract_abi: None
+        contract_interface: None
     }
 }
 

--- a/components/chainhook-sdk/src/indexer/stacks/mod.rs
+++ b/components/chainhook-sdk/src/indexer/stacks/mod.rs
@@ -112,6 +112,7 @@ pub struct NewTransaction {
     pub raw_result: String,
     pub raw_tx: String,
     pub execution_cost: Option<StacksTransactionExecutionCost>,
+    pub contract_abi: Option<ContractInterface>,
     pub contract_interface: Option<ContractInterface>,
 }
 
@@ -456,7 +457,7 @@ pub fn standardize_stacks_block(
                 description,
                 position: StacksTransactionPosition::anchor_block(tx.tx_index),
                 proof: None,
-                contract_abi: tx.contract_interface.clone(),
+                contract_abi: tx.contract_interface.clone().or(tx.contract_abi.clone()),
             },
         });
     }

--- a/components/chainhook-sdk/src/indexer/stacks/mod.rs
+++ b/components/chainhook-sdk/src/indexer/stacks/mod.rs
@@ -112,7 +112,7 @@ pub struct NewTransaction {
     pub raw_result: String,
     pub raw_tx: String,
     pub execution_cost: Option<StacksTransactionExecutionCost>,
-    pub contract_abi: Option<ContractInterface>,
+    pub contract_interface: Option<ContractInterface>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -456,7 +456,7 @@ pub fn standardize_stacks_block(
                 description,
                 position: StacksTransactionPosition::anchor_block(tx.tx_index),
                 proof: None,
-                contract_abi: tx.contract_abi.clone(),
+                contract_abi: tx.contract_interface.clone(),
             },
         });
     }

--- a/components/chainhook-sdk/src/indexer/stacks/mod.rs
+++ b/components/chainhook-sdk/src/indexer/stacks/mod.rs
@@ -112,8 +112,9 @@ pub struct NewTransaction {
     pub raw_result: String,
     pub raw_tx: String,
     pub execution_cost: Option<StacksTransactionExecutionCost>,
-    pub contract_abi: Option<ContractInterface>,
     pub contract_interface: Option<ContractInterface>,
+    /// @deprecated Use `contract_interface` instead
+    pub contract_abi: Option<ContractInterface>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -457,7 +458,7 @@ pub fn standardize_stacks_block(
                 description,
                 position: StacksTransactionPosition::anchor_block(tx.tx_index),
                 proof: None,
-                contract_abi: tx.contract_interface.clone().or(tx.contract_abi.clone()),
+                contract_abi: tx.contract_interface.clone().or_else(|| tx.contract_abi.clone()),
             },
         });
     }


### PR DESCRIPTION
Reads a deployed smart contract ABI from `contract_interface` instead of `contract_abi` in `/new_block` events. We still keep support for the old property in case someone runs chainhook with an older Stacks node or TSV file.