### PR TITLE
feat: send payload http requests using a thread pool

### DIFF
--- a/components/chainhook-cli/src/config/file.rs
+++ b/components/chainhook-cli/src/config/file.rs
@@ -68,6 +68,7 @@ pub struct NetworkConfigFile {
 #[derive(Deserialize, Debug, Clone)]
 pub struct PredicatesConfigFile {
     pub payload_http_request_timeout_ms: Option<u64>,
+    pub payload_http_request_concurrency: Option<usize>,
 }
 
 #[derive(Deserialize, Debug, Clone)]

--- a/components/chainhook-cli/src/config/file.rs
+++ b/components/chainhook-cli/src/config/file.rs
@@ -69,6 +69,8 @@ pub struct NetworkConfigFile {
 pub struct PredicatesConfigFile {
     pub payload_http_request_timeout_ms: Option<u64>,
     pub payload_http_request_concurrency: Option<usize>,
+    pub payload_http_request_attempts_max: Option<u16>,
+    pub payload_http_request_attempts_interval_ms: Option<u16>,
 }
 
 #[derive(Deserialize, Debug, Clone)]

--- a/components/chainhook-cli/src/config/mod.rs
+++ b/components/chainhook-cli/src/config/mod.rs
@@ -4,7 +4,7 @@ pub mod generator;
 use chainhook_sdk::chainhooks::types::{ChainhookStore, PoxConfig};
 pub use chainhook_sdk::indexer::IndexerConfig;
 use chainhook_sdk::observer::{
-    EventObserverConfig, PredicatesConfig, DEFAULT_PAYLOAD_HTTP_REQUEST_CONCURRENCY,
+    EventObserverConfig, PredicatesConfig, DEFAULT_PAYLOAD_HTTP_REQUEST_ATTEMPTS_INTERVAL_MS, DEFAULT_PAYLOAD_HTTP_REQUEST_ATTEMPTS_MAX, DEFAULT_PAYLOAD_HTTP_REQUEST_CONCURRENCY
 };
 use chainhook_sdk::types::{
     BitcoinBlockSignaling, BitcoinNetwork, StacksNetwork, StacksNodeConfig,
@@ -123,6 +123,8 @@ impl Config {
             predicates_config: PredicatesConfig {
                 payload_http_request_timeout_ms: self.predicates.payload_http_request_timeout_ms,
                 payload_http_request_concurrency: self.predicates.payload_http_request_concurrency,
+                payload_http_request_attempts_max: self.predicates.payload_http_request_attempts_max,
+                payload_http_request_attempts_interval_ms: self.predicates.payload_http_request_attempts_interval_ms,
             },
             bitcoind_rpc_username: self.network.bitcoind_rpc_username.clone(),
             bitcoind_rpc_password: self.network.bitcoind_rpc_password.clone(),
@@ -204,12 +206,20 @@ impl Config {
                 None => PredicatesConfig {
                     payload_http_request_timeout_ms: None,
                     payload_http_request_concurrency: DEFAULT_PAYLOAD_HTTP_REQUEST_CONCURRENCY,
+                    payload_http_request_attempts_max: DEFAULT_PAYLOAD_HTTP_REQUEST_ATTEMPTS_MAX,
+                    payload_http_request_attempts_interval_ms: DEFAULT_PAYLOAD_HTTP_REQUEST_ATTEMPTS_INTERVAL_MS,
                 },
                 Some(predicates) => PredicatesConfig {
                     payload_http_request_timeout_ms: predicates.payload_http_request_timeout_ms,
                     payload_http_request_concurrency: predicates
                         .payload_http_request_concurrency
                         .unwrap_or(DEFAULT_PAYLOAD_HTTP_REQUEST_CONCURRENCY),
+                    payload_http_request_attempts_max: predicates
+                        .payload_http_request_attempts_max
+                        .unwrap_or(DEFAULT_PAYLOAD_HTTP_REQUEST_ATTEMPTS_MAX),
+                    payload_http_request_attempts_interval_ms: predicates
+                        .payload_http_request_attempts_interval_ms
+                        .unwrap_or(DEFAULT_PAYLOAD_HTTP_REQUEST_ATTEMPTS_INTERVAL_MS),
                 },
             },
             event_sources,
@@ -390,6 +400,8 @@ impl Config {
             predicates: PredicatesConfig {
                 payload_http_request_timeout_ms: None,
                 payload_http_request_concurrency: DEFAULT_PAYLOAD_HTTP_REQUEST_CONCURRENCY,
+                payload_http_request_attempts_max: DEFAULT_PAYLOAD_HTTP_REQUEST_ATTEMPTS_MAX,
+                payload_http_request_attempts_interval_ms: DEFAULT_PAYLOAD_HTTP_REQUEST_ATTEMPTS_INTERVAL_MS,
             },
             event_sources: vec![],
             limits: LimitsConfig {
@@ -427,6 +439,8 @@ impl Config {
             predicates: PredicatesConfig {
                 payload_http_request_timeout_ms: None,
                 payload_http_request_concurrency: DEFAULT_PAYLOAD_HTTP_REQUEST_CONCURRENCY,
+                payload_http_request_attempts_max: DEFAULT_PAYLOAD_HTTP_REQUEST_ATTEMPTS_MAX,
+                payload_http_request_attempts_interval_ms: DEFAULT_PAYLOAD_HTTP_REQUEST_ATTEMPTS_INTERVAL_MS,
             },
             event_sources: vec![EventSourceConfig::StacksTsvUrl(UrlConfig {
                 file_url: DEFAULT_TESTNET_STACKS_TSV_ARCHIVE.into(),
@@ -466,6 +480,8 @@ impl Config {
             predicates: PredicatesConfig {
                 payload_http_request_timeout_ms: None,
                 payload_http_request_concurrency: DEFAULT_PAYLOAD_HTTP_REQUEST_CONCURRENCY,
+                payload_http_request_attempts_max: DEFAULT_PAYLOAD_HTTP_REQUEST_ATTEMPTS_MAX,
+                payload_http_request_attempts_interval_ms: DEFAULT_PAYLOAD_HTTP_REQUEST_ATTEMPTS_INTERVAL_MS,
             },
             event_sources: vec![EventSourceConfig::StacksTsvUrl(UrlConfig {
                 file_url: DEFAULT_MAINNET_STACKS_TSV_ARCHIVE.into(),

--- a/components/chainhook-cli/src/config/mod.rs
+++ b/components/chainhook-cli/src/config/mod.rs
@@ -3,7 +3,9 @@ pub mod generator;
 
 use chainhook_sdk::chainhooks::types::{ChainhookStore, PoxConfig};
 pub use chainhook_sdk::indexer::IndexerConfig;
-use chainhook_sdk::observer::{EventObserverConfig, PredicatesConfig};
+use chainhook_sdk::observer::{
+    EventObserverConfig, PredicatesConfig, DEFAULT_PAYLOAD_HTTP_REQUEST_CONCURRENCY,
+};
 use chainhook_sdk::types::{
     BitcoinBlockSignaling, BitcoinNetwork, StacksNetwork, StacksNodeConfig,
 };
@@ -120,6 +122,7 @@ impl Config {
             registered_chainhooks: ChainhookStore::new(),
             predicates_config: PredicatesConfig {
                 payload_http_request_timeout_ms: self.predicates.payload_http_request_timeout_ms,
+                payload_http_request_concurrency: self.predicates.payload_http_request_concurrency,
             },
             bitcoind_rpc_username: self.network.bitcoind_rpc_username.clone(),
             bitcoind_rpc_password: self.network.bitcoind_rpc_password.clone(),
@@ -200,9 +203,13 @@ impl Config {
             predicates: match config_file.predicates {
                 None => PredicatesConfig {
                     payload_http_request_timeout_ms: None,
+                    payload_http_request_concurrency: DEFAULT_PAYLOAD_HTTP_REQUEST_CONCURRENCY,
                 },
                 Some(predicates) => PredicatesConfig {
                     payload_http_request_timeout_ms: predicates.payload_http_request_timeout_ms,
+                    payload_http_request_concurrency: predicates
+                        .payload_http_request_concurrency
+                        .unwrap_or(DEFAULT_PAYLOAD_HTTP_REQUEST_CONCURRENCY),
                 },
             },
             event_sources,
@@ -309,7 +316,7 @@ impl Config {
             Ok(dir) => dir,
             Err(error) => match error.kind() {
                 std::io::ErrorKind::NotFound => return Ok(true),
-                _ => return Err(format!("unable to read cache directory: {error}"))
+                _ => return Err(format!("unable to read cache directory: {error}")),
             },
         };
         Ok(dir.next().is_none())
@@ -382,6 +389,7 @@ impl Config {
             http_api: PredicatesApi::Off,
             predicates: PredicatesConfig {
                 payload_http_request_timeout_ms: None,
+                payload_http_request_concurrency: DEFAULT_PAYLOAD_HTTP_REQUEST_CONCURRENCY,
             },
             event_sources: vec![],
             limits: LimitsConfig {
@@ -418,6 +426,7 @@ impl Config {
             http_api: PredicatesApi::Off,
             predicates: PredicatesConfig {
                 payload_http_request_timeout_ms: None,
+                payload_http_request_concurrency: DEFAULT_PAYLOAD_HTTP_REQUEST_CONCURRENCY,
             },
             event_sources: vec![EventSourceConfig::StacksTsvUrl(UrlConfig {
                 file_url: DEFAULT_TESTNET_STACKS_TSV_ARCHIVE.into(),
@@ -456,6 +465,7 @@ impl Config {
             http_api: PredicatesApi::Off,
             predicates: PredicatesConfig {
                 payload_http_request_timeout_ms: None,
+                payload_http_request_concurrency: DEFAULT_PAYLOAD_HTTP_REQUEST_CONCURRENCY,
             },
             event_sources: vec![EventSourceConfig::StacksTsvUrl(UrlConfig {
                 file_url: DEFAULT_MAINNET_STACKS_TSV_ARCHIVE.into(),

--- a/components/chainhook-cli/src/scan/bitcoin.rs
+++ b/components/chainhook-cli/src/scan/bitcoin.rs
@@ -301,7 +301,7 @@ pub async fn execute_predicates_action<'a>(
                 actions_triggered += 1;
                 match action {
                     BitcoinChainhookOccurrence::Http(request, _) => {
-                        send_request(request, 10, 3, ctx).await?
+                        send_request(request, &config.predicates_config, ctx).await?
                     }
                     BitcoinChainhookOccurrence::File(path, bytes) => {
                         file_append(path, bytes, ctx)?

--- a/components/chainhook-cli/src/scan/stacks.rs
+++ b/components/chainhook-cli/src/scan/stacks.rs
@@ -370,7 +370,7 @@ pub async fn scan_stacks_chainstate_via_rocksdb_using_predicate(
                 loop_did_trigger = true;
                 let res = match action {
                     StacksChainhookOccurrence::Http(request, _) => {
-                        send_request(request, 3, 1, ctx).await
+                        send_request(request, &config.predicates, ctx).await
                     }
                     StacksChainhookOccurrence::File(path, bytes) => file_append(path, bytes, ctx),
                     StacksChainhookOccurrence::Data(_payload) => Ok(()),
@@ -557,7 +557,7 @@ pub async fn scan_stacks_chainstate_via_csv_using_predicate(
                 occurrences_found += 1;
                 let res = match action {
                     StacksChainhookOccurrence::Http(request, _) => {
-                        send_request(request, 10, 3, ctx).await
+                        send_request(request, &config.predicates, ctx).await
                     }
                     StacksChainhookOccurrence::File(path, bytes) => file_append(path, bytes, ctx),
                     StacksChainhookOccurrence::Data(_payload) => unreachable!(),

--- a/components/chainhook-sdk/src/observer/mod.rs
+++ b/components/chainhook-sdk/src/observer/mod.rs
@@ -42,12 +42,13 @@ use std::error::Error;
 use std::net::{IpAddr, Ipv4Addr};
 use std::str;
 use std::str::FromStr;
-use std::sync::atomic::AtomicBool;
 use std::sync::mpsc::{Receiver, Sender};
 use std::sync::{Arc, Mutex, RwLock};
 
 pub const DEFAULT_INGESTION_PORT: u16 = 20445;
 pub const DEFAULT_PAYLOAD_HTTP_REQUEST_CONCURRENCY: usize = 10;
+pub const DEFAULT_PAYLOAD_HTTP_REQUEST_ATTEMPTS_MAX: u16 = 3;
+pub const DEFAULT_PAYLOAD_HTTP_REQUEST_ATTEMPTS_INTERVAL_MS: u16 = 100;
 
 #[derive(Deserialize)]
 pub struct NewTransaction {
@@ -72,6 +73,8 @@ pub enum DataHandlerEvent {
 pub struct PredicatesConfig {
     pub payload_http_request_timeout_ms: Option<u64>,
     pub payload_http_request_concurrency: usize,
+    pub payload_http_request_attempts_max: u16,
+    pub payload_http_request_attempts_interval_ms: u16,
 }
 
 impl PredicatesConfig {
@@ -79,6 +82,9 @@ impl PredicatesConfig {
         PredicatesConfig {
             payload_http_request_timeout_ms: None,
             payload_http_request_concurrency: DEFAULT_PAYLOAD_HTTP_REQUEST_CONCURRENCY,
+            payload_http_request_attempts_max: DEFAULT_PAYLOAD_HTTP_REQUEST_ATTEMPTS_MAX,
+            payload_http_request_attempts_interval_ms:
+                DEFAULT_PAYLOAD_HTTP_REQUEST_ATTEMPTS_INTERVAL_MS,
         }
     }
 }
@@ -317,6 +323,9 @@ impl BitcoinEventObserverConfigBuilder {
             predicates_config: PredicatesConfig {
                 payload_http_request_timeout_ms: None,
                 payload_http_request_concurrency: DEFAULT_PAYLOAD_HTTP_REQUEST_CONCURRENCY,
+                payload_http_request_attempts_max: DEFAULT_PAYLOAD_HTTP_REQUEST_ATTEMPTS_MAX,
+                payload_http_request_attempts_interval_ms:
+                    DEFAULT_PAYLOAD_HTTP_REQUEST_ATTEMPTS_INTERVAL_MS,
             },
             bitcoin_rpc_proxy_enabled: false,
             bitcoind_rpc_username: self
@@ -351,6 +360,9 @@ impl EventObserverConfig {
             predicates_config: PredicatesConfig {
                 payload_http_request_timeout_ms: None,
                 payload_http_request_concurrency: DEFAULT_PAYLOAD_HTTP_REQUEST_CONCURRENCY,
+                payload_http_request_attempts_max: DEFAULT_PAYLOAD_HTTP_REQUEST_ATTEMPTS_MAX,
+                payload_http_request_attempts_interval_ms:
+                    DEFAULT_PAYLOAD_HTTP_REQUEST_ATTEMPTS_INTERVAL_MS,
             },
             bitcoin_rpc_proxy_enabled: false,
             bitcoind_rpc_username: "devnet".into(),
@@ -437,6 +449,9 @@ impl EventObserverConfig {
             predicates_config: PredicatesConfig {
                 payload_http_request_timeout_ms: None,
                 payload_http_request_concurrency: DEFAULT_PAYLOAD_HTTP_REQUEST_CONCURRENCY,
+                payload_http_request_attempts_max: DEFAULT_PAYLOAD_HTTP_REQUEST_ATTEMPTS_MAX,
+                payload_http_request_attempts_interval_ms:
+                    DEFAULT_PAYLOAD_HTTP_REQUEST_ATTEMPTS_INTERVAL_MS,
             },
             bitcoind_rpc_username: overrides
                 .and_then(|c| c.bitcoind_rpc_username.clone())
@@ -1569,11 +1584,9 @@ pub async fn start_observer_commands_handler(
                 }
 
                 // Send all Bitcoin chainhook requests using a thread pool
-                for (result, data) in send_concurrent_http_requests(
-                    requests,
-                    config.predicates_config.payload_http_request_concurrency,
-                    &ctx,
-                ) {
+                for (result, data) in
+                    send_concurrent_http_requests(requests, &config.predicates_config, &ctx)
+                {
                     match result {
                         Ok(_) => {
                             if let Some(ref tx) = observer_events_tx {
@@ -1764,11 +1777,9 @@ pub async fn start_observer_commands_handler(
                 }
 
                 // Send all Stacks chainhook requests using a thread pool
-                for (result, data) in send_concurrent_http_requests(
-                    requests,
-                    config.predicates_config.payload_http_request_concurrency,
-                    &ctx,
-                ) {
+                for (result, data) in
+                    send_concurrent_http_requests(requests, &config.predicates_config, &ctx)
+                {
                     match result {
                         Ok(_) => {
                             if let Some(ref tx) = observer_events_tx {

--- a/components/chainhook-sdk/src/observer/mod.rs
+++ b/components/chainhook-sdk/src/observer/mod.rs
@@ -21,7 +21,7 @@ use crate::indexer::bitcoin::{
 };
 use crate::indexer::{Indexer, IndexerConfig};
 use crate::monitoring::{start_serving_prometheus_metrics, PrometheusMonitoring};
-use crate::utils::{send_request, Context};
+use crate::utils::{send_concurrent_http_requests, Context};
 
 use bitcoincore_rpc::bitcoin::{BlockHash, Txid};
 use bitcoincore_rpc::{Auth, Client, RpcApi};
@@ -42,10 +42,12 @@ use std::error::Error;
 use std::net::{IpAddr, Ipv4Addr};
 use std::str;
 use std::str::FromStr;
+use std::sync::atomic::AtomicBool;
 use std::sync::mpsc::{Receiver, Sender};
 use std::sync::{Arc, Mutex, RwLock};
 
 pub const DEFAULT_INGESTION_PORT: u16 = 20445;
+pub const DEFAULT_PAYLOAD_HTTP_REQUEST_CONCURRENCY: usize = 10;
 
 #[derive(Deserialize)]
 pub struct NewTransaction {
@@ -69,12 +71,14 @@ pub enum DataHandlerEvent {
 #[derive(Clone, Debug, PartialEq)]
 pub struct PredicatesConfig {
     pub payload_http_request_timeout_ms: Option<u64>,
+    pub payload_http_request_concurrency: usize,
 }
 
 impl PredicatesConfig {
     pub fn new() -> Self {
         PredicatesConfig {
             payload_http_request_timeout_ms: None,
+            payload_http_request_concurrency: DEFAULT_PAYLOAD_HTTP_REQUEST_CONCURRENCY,
         }
     }
 }
@@ -312,6 +316,7 @@ impl BitcoinEventObserverConfigBuilder {
             registered_chainhooks: ChainhookStore::new(),
             predicates_config: PredicatesConfig {
                 payload_http_request_timeout_ms: None,
+                payload_http_request_concurrency: DEFAULT_PAYLOAD_HTTP_REQUEST_CONCURRENCY,
             },
             bitcoin_rpc_proxy_enabled: false,
             bitcoind_rpc_username: self
@@ -345,6 +350,7 @@ impl EventObserverConfig {
             registered_chainhooks: ChainhookStore::new(),
             predicates_config: PredicatesConfig {
                 payload_http_request_timeout_ms: None,
+                payload_http_request_concurrency: DEFAULT_PAYLOAD_HTTP_REQUEST_CONCURRENCY,
             },
             bitcoin_rpc_proxy_enabled: false,
             bitcoind_rpc_username: "devnet".into(),
@@ -430,6 +436,7 @@ impl EventObserverConfig {
             registered_chainhooks: ChainhookStore::new(),
             predicates_config: PredicatesConfig {
                 payload_http_request_timeout_ms: None,
+                payload_http_request_concurrency: DEFAULT_PAYLOAD_HTTP_REQUEST_CONCURRENCY,
             },
             bitcoind_rpc_username: overrides
                 .and_then(|c| c.bitcoind_rpc_username.clone())
@@ -1042,6 +1049,7 @@ pub async fn start_stacks_event_observer(
         .mount("/", routes)
         .ignite()
         .await?;
+
     let ingestion_shutdown = Some(ignite.shutdown());
 
     let _ = std::thread::spawn(move || {
@@ -1560,8 +1568,13 @@ pub async fn start_observer_commands_handler(
                     }
                 }
 
-                for (request, data) in requests.into_iter() {
-                    match send_request(request, 3, 1, &ctx).await {
+                // Send all Bitcoin chainhook requests using a thread pool
+                for (result, data) in send_concurrent_http_requests(
+                    requests,
+                    config.predicates_config.payload_http_request_concurrency,
+                    &ctx,
+                ) {
+                    match result {
                         Ok(_) => {
                             if let Some(ref tx) = observer_events_tx {
                                 let _ = tx.send(ObserverEvent::BitcoinPredicateTriggered(data));
@@ -1576,7 +1589,7 @@ pub async fn start_observer_commands_handler(
                                 }));
                             }
                         }
-                    }
+                    };
                 }
 
                 prometheus_monitoring.btc_metrics_block_evaluated(new_tip);
@@ -1750,16 +1763,13 @@ pub async fn start_observer_commands_handler(
                     }
                 }
 
-                for (request, data) in requests.into_iter() {
-                    // todo(lgalabru): collect responses for reporting
-                    ctx.try_log(|logger| {
-                        slog::debug!(
-                            logger,
-                            "Dispatching request from stacks chainhook {:?}",
-                            request
-                        )
-                    });
-                    match send_request(request, 3, 1, &ctx).await {
+                // Send all Stacks chainhook requests using a thread pool
+                for (result, data) in send_concurrent_http_requests(
+                    requests,
+                    config.predicates_config.payload_http_request_concurrency,
+                    &ctx,
+                ) {
+                    match result {
                         Ok(_) => {
                             if let Some(ref tx) = observer_events_tx {
                                 let _ = tx.send(ObserverEvent::StacksPredicateTriggered(data));

--- a/components/chainhook-sdk/src/utils/mod.rs
+++ b/components/chainhook-sdk/src/utils/mod.rs
@@ -1,8 +1,5 @@
 use std::{
-    collections::{BTreeSet, VecDeque},
-    fs::{self, OpenOptions},
-    io::{Read, Write},
-    path::PathBuf,
+    collections::{BTreeSet, VecDeque}, fs::{self, OpenOptions}, io::{Read, Write}, path::PathBuf, sync::{Arc, Mutex}, thread
 };
 
 use chainhook_types::{
@@ -11,6 +8,7 @@ use chainhook_types::{
 use hiro_system_kit::slog::{self, Logger};
 use reqwest::RequestBuilder;
 use serde_json::Value as JsonValue;
+use crate::{try_info, try_warn};
 
 #[derive(Clone)]
 pub struct Context {
@@ -161,20 +159,20 @@ pub async fn send_request(
         let err_msg = match request_builder.send().await {
             Ok(res) => {
                 if res.status().is_success() {
-                    ctx.try_log(|logger| slog::debug!(logger, "Trigger {} successful", res.url()));
+                    try_info!(ctx, "Trigger {} successful", res.url());
                     return Ok(());
                 } else {
                     retry += 1;
                     let err_msg =
                         format!("Trigger {} failed with status {}", res.url(), res.status());
-                    ctx.try_log(|logger| slog::warn!(logger, "{}", err_msg));
+                    try_warn!(ctx, "{}", err_msg);
                     err_msg
                 }
             }
             Err(e) => {
                 retry += 1;
                 let err_msg = format!("unable to send request {}", e);
-                ctx.try_log(|logger| slog::warn!(logger, "{}", err_msg));
+                try_warn!(ctx, "{}", err_msg);
                 err_msg
             }
         };
@@ -183,11 +181,76 @@ pub async fn send_request(
                 "unable to send request after several retries. most recent error: {}",
                 err_msg
             );
-            ctx.try_log(|logger| slog::warn!(logger, "{}", msg));
+            try_warn!(ctx, "{}", msg);
             return Err(msg);
         }
         std::thread::sleep(std::time::Duration::from_secs(attempts_interval_sec.into()));
     }
+}
+
+/// Processes requests in parallel using a thread pool with a configurable maximum number of threads.
+/// Each request is processed by calling the provided closure with the request and data.
+pub fn send_concurrent_http_requests<D>(
+    requests: Vec<(RequestBuilder, D)>,
+    concurrency: usize,
+    ctx: &Context,
+) -> Vec<(Result<(), String>, D)>
+where D: Send + 'static,
+{
+    let request_count = requests.len();
+    if request_count == 0 {
+        return Vec::new();
+    }
+
+    let (tx_requests, rx_requests) = std::sync::mpsc::channel();
+    let (tx_results, rx_results) = std::sync::mpsc::channel();
+    let mut handles = Vec::new();
+
+    // Send all requests to the queue
+    for (request, data) in requests.into_iter() {
+        let _ = tx_requests.send((request, data));
+    }
+    drop(tx_requests); // Signal that no more requests will be sent
+
+    // Spawn worker threads (max_threads, or fewer if we have fewer requests)
+    let num_threads = std::cmp::min(concurrency, std::cmp::max(1, request_count));
+    let rx_requests_shared = Arc::new(Mutex::new(rx_requests));
+    for _ in 0..num_threads {
+        let rx_requests_shared_clone = rx_requests_shared.clone();
+        let tx_results_clone = tx_results.clone();
+        let ctx_clone = ctx.clone();
+        let handle = thread::spawn(move || {
+            loop {
+                let request_data = {
+                    let rx_guard = rx_requests_shared_clone.lock().unwrap();
+                    rx_guard.recv()
+                };
+                match request_data {
+                    Ok((request, data)) => {
+                        let result = hiro_system_kit::nestable_block_on(send_request(
+                            request, 1, 1, &ctx_clone,
+                        ))
+                        .map_err(|e| e.to_string());
+                        let _ = tx_results_clone.send((result, data));
+                    }
+                    Err(_) => break, // Channel closed, no more requests
+                }
+            }
+        });
+        handles.push(handle);
+    }
+
+    // Wait for all threads to complete
+    for handle in handles {
+        let _ = handle.join();
+    }
+
+    // Collect all results
+    let mut results = Vec::new();
+    while let Ok((result, data)) = rx_results.try_recv() {
+        results.push((result, data));
+    }
+    results
 }
 
 pub fn file_append(path: String, bytes: Vec<u8>, ctx: &Context) -> Result<(), String> {

--- a/components/chainhook-sdk/src/utils/mod.rs
+++ b/components/chainhook-sdk/src/utils/mod.rs
@@ -8,7 +8,7 @@ use chainhook_types::{
 use hiro_system_kit::slog::{self, Logger};
 use reqwest::RequestBuilder;
 use serde_json::Value as JsonValue;
-use crate::{try_info, try_warn};
+use crate::{observer::PredicatesConfig, try_info, try_warn};
 
 #[derive(Clone)]
 pub struct Context {
@@ -143,8 +143,7 @@ impl AbstractBlock for BitcoinBlockData {
 
 pub async fn send_request(
     request_builder: RequestBuilder,
-    attempts_max: u16,
-    attempts_interval_sec: u16,
+    config: &PredicatesConfig,
     ctx: &Context,
 ) -> Result<(), String> {
     let mut retry = 0;
@@ -176,7 +175,7 @@ pub async fn send_request(
                 err_msg
             }
         };
-        if retry >= attempts_max {
+        if retry >= config.payload_http_request_attempts_max {
             let msg: String = format!(
                 "unable to send request after several retries. most recent error: {}",
                 err_msg
@@ -184,7 +183,7 @@ pub async fn send_request(
             try_warn!(ctx, "{}", msg);
             return Err(msg);
         }
-        std::thread::sleep(std::time::Duration::from_secs(attempts_interval_sec.into()));
+        std::thread::sleep(std::time::Duration::from_millis(config.payload_http_request_attempts_interval_ms.into()));
     }
 }
 
@@ -192,7 +191,7 @@ pub async fn send_request(
 /// Each request is processed by calling the provided closure with the request and data.
 pub fn send_concurrent_http_requests<D>(
     requests: Vec<(RequestBuilder, D)>,
-    concurrency: usize,
+    config: &PredicatesConfig,
     ctx: &Context,
 ) -> Vec<(Result<(), String>, D)>
 where D: Send + 'static,
@@ -213,12 +212,13 @@ where D: Send + 'static,
     drop(tx_requests); // Signal that no more requests will be sent
 
     // Spawn worker threads (max_threads, or fewer if we have fewer requests)
-    let num_threads = std::cmp::min(concurrency, std::cmp::max(1, request_count));
+    let num_threads = std::cmp::min(config.payload_http_request_concurrency, std::cmp::max(1, request_count));
     let rx_requests_shared = Arc::new(Mutex::new(rx_requests));
     for _ in 0..num_threads {
         let rx_requests_shared_clone = rx_requests_shared.clone();
         let tx_results_clone = tx_results.clone();
         let ctx_clone = ctx.clone();
+        let config_clone = config.clone();
         let handle = thread::spawn(move || {
             loop {
                 let request_data = {
@@ -228,7 +228,7 @@ where D: Send + 'static,
                 match request_data {
                     Ok((request, data)) => {
                         let result = hiro_system_kit::nestable_block_on(send_request(
-                            request, 1, 1, &ctx_clone,
+                            request, &config_clone, &ctx_clone,
                         ))
                         .map_err(|e| e.to_string());
                         let _ = tx_results_clone.send((result, data));

--- a/components/chainhook-sdk/src/utils/mod.rs
+++ b/components/chainhook-sdk/src/utils/mod.rs
@@ -1,14 +1,21 @@
 use std::{
-    collections::{BTreeSet, VecDeque}, fs::{self, OpenOptions}, io::{Read, Write}, path::PathBuf, sync::{Arc, Mutex}, thread
+    collections::{BTreeSet, VecDeque},
+    fs::{self, OpenOptions},
+    io::{Read, Write},
+    path::PathBuf,
+    sync::{Arc, Mutex},
+    thread::{self, sleep},
+    time::Duration,
 };
 
+use crate::{observer::PredicatesConfig, try_info, try_warn};
 use chainhook_types::{
-    BitcoinBlockData, BlockHeader, BlockIdentifier, StacksBlockData, StacksMicroblockData, StacksTransactionData
+    BitcoinBlockData, BlockHeader, BlockIdentifier, StacksBlockData, StacksMicroblockData,
+    StacksTransactionData,
 };
 use hiro_system_kit::slog::{self, Logger};
 use reqwest::RequestBuilder;
 use serde_json::Value as JsonValue;
-use crate::{observer::PredicatesConfig, try_info, try_warn};
 
 #[derive(Clone)]
 pub struct Context {
@@ -151,39 +158,38 @@ pub async fn send_request(
         let request_builder = match request_builder.try_clone() {
             Some(rb) => rb,
             None => {
-                ctx.try_log(|logger| slog::warn!(logger, "unable to clone request builder"));
+                try_warn!(ctx, "unable to clone request builder");
                 return Err("internal server error: unable to clone request builder".to_string());
             }
         };
         let err_msg = match request_builder.send().await {
             Ok(res) => {
                 if res.status().is_success() {
-                    try_info!(ctx, "Trigger {} successful", res.url());
+                    try_info!(ctx, "Request {} successful", res.url());
                     return Ok(());
                 } else {
                     retry += 1;
                     let err_msg =
-                        format!("Trigger {} failed with status {}", res.url(), res.status());
-                    try_warn!(ctx, "{}", err_msg);
+                        format!("Request {} failed with status {}", res.url(), res.status());
+                    try_warn!(ctx, "{err_msg}");
                     err_msg
                 }
             }
             Err(e) => {
                 retry += 1;
-                let err_msg = format!("unable to send request {}", e);
-                try_warn!(ctx, "{}", err_msg);
+                let err_msg = format!("Request error: {e}");
+                try_warn!(ctx, "{err_msg}");
                 err_msg
             }
         };
         if retry >= config.payload_http_request_attempts_max {
-            let msg: String = format!(
-                "unable to send request after several retries. most recent error: {}",
-                err_msg
-            );
-            try_warn!(ctx, "{}", msg);
+            let msg = format!("Request failed after max attempts. most recent error: {err_msg}");
+            try_warn!(ctx, "{msg}");
             return Err(msg);
         }
-        std::thread::sleep(std::time::Duration::from_millis(config.payload_http_request_attempts_interval_ms.into()));
+        sleep(Duration::from_millis(
+            config.payload_http_request_attempts_interval_ms.into(),
+        ));
     }
 }
 
@@ -194,7 +200,8 @@ pub fn send_concurrent_http_requests<D>(
     config: &PredicatesConfig,
     ctx: &Context,
 ) -> Vec<(Result<(), String>, D)>
-where D: Send + 'static,
+where
+    D: Send + 'static,
 {
     let request_count = requests.len();
     if request_count == 0 {
@@ -212,8 +219,13 @@ where D: Send + 'static,
     drop(tx_requests); // Signal that no more requests will be sent
 
     // Spawn worker threads (max_threads, or fewer if we have fewer requests)
-    let num_threads = std::cmp::min(config.payload_http_request_concurrency, std::cmp::max(1, request_count));
+    let num_threads = std::cmp::min(
+        config.payload_http_request_concurrency,
+        std::cmp::max(1, request_count),
+    );
     let rx_requests_shared = Arc::new(Mutex::new(rx_requests));
+    try_info!(ctx, "Sending {request_count} total requests across {num_threads} worker threads");
+
     for _ in 0..num_threads {
         let rx_requests_shared_clone = rx_requests_shared.clone();
         let tx_results_clone = tx_results.clone();
@@ -228,7 +240,9 @@ where D: Send + 'static,
                 match request_data {
                     Ok((request, data)) => {
                         let result = hiro_system_kit::nestable_block_on(send_request(
-                            request, &config_clone, &ctx_clone,
+                            request,
+                            &config_clone,
+                            &ctx_clone,
                         ))
                         .map_err(|e| e.to_string());
                         let _ = tx_results_clone.send((result, data));
@@ -269,11 +283,7 @@ pub fn file_append(path: String, bytes: Vec<u8>, ctx: &Context) -> Result<(), St
                 let _ = file.write_all(&bytes);
             }
             Err(e) => {
-                let msg = format!(
-                    "unable to create file {}: {}",
-                    file_path.display(),
-                    e
-                );
+                let msg = format!("unable to create file {}: {}", file_path.display(), e);
                 ctx.try_log(|logger| slog::warn!(logger, "{}", msg));
                 return Err(msg);
             }
@@ -282,7 +292,6 @@ pub fn file_append(path: String, bytes: Vec<u8>, ctx: &Context) -> Result<(), St
 
     let mut file = match OpenOptions::new()
         .create(false)
-        
         .append(true)
         .open(file_path)
     {


### PR DESCRIPTION
Adds 3 config options that allow us to control the size of the thread pool and how many attempts we should make per request:

```toml
[predicates]
payload_http_request_concurrency = 20
payload_http_request_attempts_max = 3
payload_http_request_attempts_interval_ms = 100
```