### PR TITLE
ci: support npm trusted publishers

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
         working-directory: ./components/chainhook-${{ matrix.suite }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 
@@ -71,7 +71,7 @@ jobs:
           cargo tarpaulin --skip-clean --out lcov --features ${{ matrix.features }} -- --test-threads=1
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         env:
           token: ${{ secrets.CODECOV_TOKEN }}
           codecov_yml_path: .github/codecov.yml
@@ -117,7 +117,7 @@ jobs:
           git config --global core.eol lf
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         run: rustup toolchain install stable --profile minimal --target ${{ matrix.target }}
@@ -266,14 +266,14 @@ jobs:
       # Separate uploads to prevent paths from being preserved
       - name: Upload cargo artifacts (Linux)
         if: matrix.os != 'windows-latest'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: chainhook-${{ env.SHORT_TARGET_NAME }}
           path: chainhook-${{ env.SHORT_TARGET_NAME }}.tar.gz
 
       - name: Upload cargo artifact (Windows)
         if: matrix.os == 'windows-latest'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: chainhook-${{ env.SHORT_TARGET_NAME }}
           path: chainhook-${{ env.SHORT_TARGET_NAME }}.msi
@@ -281,6 +281,7 @@ jobs:
   semantic-release:
     permissions:
       contents: write
+      id-token: write
       issues: write
       pull-requests: write
     runs-on: ubuntu-latest
@@ -293,12 +294,12 @@ jobs:
     steps:
       - name: Generate release bot app token
         id: generate_token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.HIROSYSTEMS_RELEASE_BOT_ID }}
           private-key: ${{ secrets.HIROSYSTEMS_RELEASE_BOT_PEM }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
 
@@ -310,10 +311,10 @@ jobs:
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}
 
       - name: Download pre-built dists
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
 
       - name: Semantic Release
-        uses: cycjimmy/semantic-release-action@v4
+        uses: cycjimmy/semantic-release-action@9cc899c47e6841430bbaedb43de1560a568dfd16 # v5
         id: semantic
         # Only run on non-PR events or only PRs that aren't from forks
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
@@ -324,15 +325,14 @@ jobs:
           GIT_AUTHOR_EMAIL: "${{ steps.bot-user-id.outputs.user-id }}+${{ steps.generate_token.outputs.app-slug }}[bot]@users.noreply.github.com"
           GIT_COMMITTER_EMAIL: "${{ steps.bot-user-id.outputs.user-id }}+${{ steps.generate_token.outputs.app-slug }}[bot]@users.noreply.github.com"
         with:
-          semantic_version: 19
           extra_plugins: |
             @semantic-release/changelog@6.0.3
             @semantic-release/git@10.0.1
-            @semantic-release/exec@6.0.3
-            conventional-changelog-conventionalcommits@6.1.0
+            @semantic-release/exec@7.1.0
+            conventional-changelog-conventionalcommits@9.1.0
 
       - name: Trigger pkg-version-bump workflow
-        uses: peter-evans/repository-dispatch@v1
+        uses: peter-evans/repository-dispatch@v4
         if: steps.semantic.outputs.new_release_version != ''
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -352,13 +352,13 @@ jobs:
             artifact: chainhook-linux-x64-glibc
             dockerfile: dockerfiles/components/chainhook-node.dockerfile
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
 
       - name: Checkout tag
         if: needs.semantic-release.outputs.new_release_version != ''
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
           ref: ${{ needs.semantic-release.outputs.new_release_git_tag }}
@@ -386,7 +386,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Download pre-built dist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: ${{ matrix.artifact }}
 
@@ -394,7 +394,7 @@ jobs:
         run: tar zxvf *.tar.gz
 
       - name: Build/Push Image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         id: docker_push
         with:
           context: .
@@ -420,7 +420,7 @@ jobs:
       url: https://platform.dev.hiro.so/
     steps:
       - name: Checkout actions repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
           token: ${{ secrets.GH_TOKEN }}
@@ -463,7 +463,7 @@ jobs:
       url: https://platform.stg.hiro.so/
     steps:
       - name: Checkout actions repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
           token: ${{ secrets.GH_TOKEN }}
@@ -513,7 +513,7 @@ jobs:
       url: https://platform.hiro.so/
     steps:
       - name: Checkout actions repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
           token: ${{ secrets.GH_TOKEN }}

--- a/.releaserc
+++ b/.releaserc
@@ -28,6 +28,20 @@
     [
       "@semantic-release/exec",
       {
+        "execCwd": "components/client/typescript",
+        "prepareCmd": "npm ci"
+      }
+    ],
+    [
+      "@semantic-release/npm",
+      {
+        "pkgRoot": "./components/client/typescript",
+        "npmPublish": true
+      }
+    ],
+    [
+      "@semantic-release/exec",
+      {
         "prepareCmd": "sed -i -e '1h;2,$H;$!d;g' -e 's@name = \"chainhook\"\\nversion = \"[^\"]*\"@name = \"chainhook\"\\nversion = \"${nextRelease.version}\"@g' Cargo.toml Cargo.lock"
       }
     ],
@@ -38,6 +52,8 @@
       {
         "assets": [
           "CHANGELOG.md",
+          "components/client/typescript/package.json",
+          "components/client/typescript/package-lock.json",
           "components/chainhook-cli/Cargo.toml",
           "components/chainhook-cli/Cargo.lock"
         ]


### PR DESCRIPTION
Related https://github.com/hirosystems/devops/issues/2230

* Adds NPM package to be managed and published by Semantic Release
* Adds support for [NPM trusted publishers](https://docs.npmjs.com/trusted-publishers)
* Updates GH actions