### PR TITLE
docs: populate troubleshooting guide and fix install command in getting-started

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,6 +11,14 @@ Chainhook can extract data from the Bitcoin and the Stacks blockchains using pre
 - **Chainhook as a development tool** has a few convenient features designed to make developers as productive as possible by allowing them to iterate quickly in their local environments.
 - **Chainhook as a service** can be used to evaluate new Bitcoin and/or Stacks blocks against your predicates. You can also dynamically register new predicates by [enabling predicates registration API](./overview.md#then-that-predicate-design).
 
+## Prerequisites
+
+Before installing Chainhook, ensure you have the following:
+
+- [Rust toolchain](https://rustup.rs/) (stable) — required to build from source
+- `git` — to clone the repository
+- A C compiler and `pkg-config` (on Linux: `build-essential`, `libssl-dev`)
+
 ## Install Chainhook from the Source
 
 Chainhook can be installed from the source by following the steps below:
@@ -27,13 +35,20 @@ Chainhook can be installed from the source by following the steps below:
    cd chainhook
    ```
 
-3. Run cargo target to install chainhook:
+3. Build and install the Chainhook CLI:
 
     ```bash
-    cargo chainhook-install
+    cargo install --path components/chainhook-cli
+    ```
+
+4. Verify the installation:
+
+    ```bash
+    chainhook --version
     ```
 
 If you want to start using Chainhook for extracting data from Bitcoin or Stacks, you can design your predicates using the following guides:
 
 - [How to use chainhooks with bitcoin](./how-to-guides/how-to-use-chainhooks-with-bitcoin.md)
 - [How to use chainhooks with stacks](./how-to-guides/how-to-use-chainhooks-with-stacks.md)
+- [Troubleshooting common issues](./troubleshooting.md)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,6 +2,76 @@
 title: Troubleshooting guide
 ---
 
-# Title
+# Troubleshooting Guide
 
-<!-- Text to be added soon -->
+This guide covers common issues you may encounter when setting up or running Chainhook, along with their solutions.
+
+## Installation Issues
+
+### Rust toolchain not found
+
+If you see an error like `rustup: command not found` or `cargo: command not found`, you need to install the Rust toolchain first:
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source $HOME/.cargo/env
+```
+
+### Build fails with missing dependencies
+
+On Ubuntu/Debian, you may need to install build essentials and OpenSSL dev headers:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y build-essential pkg-config libssl-dev
+```
+
+On macOS, ensure Xcode command line tools are installed:
+
+```bash
+xcode-select --install
+```
+
+## Configuration Issues
+
+### Chainhook fails to connect to the Bitcoin node
+
+- Verify that `bitcoind` is running and the RPC port is accessible.
+- Check the `bitcoin_node_rpc_url` in your `Chainhook.toml` matches your node's configuration.
+- Ensure the RPC username and password are correct.
+
+### Chainhook fails to connect to the Stacks node
+
+- Verify that `stacks-node` is running and the RPC endpoint is accessible.
+- Check `stacks_node_rpc_url` in your configuration.
+- If using Docker, make sure the containers are on the same network.
+
+## Runtime Issues
+
+### Predicate not triggering
+
+- Double-check your predicate definition for typos in contract addresses, function names, or event types.
+- Ensure the `start_block` is set to a block height before the expected event.
+- Verify the `chain` field matches the network you are targeting (`mainnet` or `testnet`).
+
+### High memory usage during scanning
+
+When scanning large block ranges, Chainhook may consume significant memory. Consider:
+
+- Narrowing the `start_block` and `end_block` range in your predicate.
+- Running scanning operations on a machine with sufficient RAM (4 GB+ recommended).
+- Using `end_block` to limit the scan to a specific range before extending it.
+
+### Webhook endpoint not receiving payloads
+
+- Ensure your `http_post` URL is reachable from the machine running Chainhook.
+- Check firewall rules to make sure the port is open.
+- Look at Chainhook logs for delivery errors or HTTP status codes.
+
+## Getting Help
+
+If you are still experiencing issues:
+
+- Search for existing issues on the [Chainhook GitHub repository](https://github.com/hirosystems/chainhook/issues).
+- Open a new issue with detailed logs and your predicate configuration (remove any sensitive information).
+- Join the [Stacks Discord](https://discord.gg/stacks) for community support.


### PR DESCRIPTION
## Description

Improved the documentation to help new users get started more easily.

### Changes

#### `docs/troubleshooting.md`
- Populated the previously empty troubleshooting guide with practical solutions for common issues:
  - Installation issues (Rust toolchain, missing deps)
  - Configuration issues (Bitcoin/Stacks node connection)
  - Runtime issues (predicates not triggering, high memory usage, webhook failures)
  - Links to community support channels

#### `docs/getting-started.md`
- Fixed incorrect install command: `cargo chainhook-install` -> `cargo install --path components/chainhook-cli`
- Added a Prerequisites section listing required tools (Rust toolchain, git, C compiler)
- Added a verification step (`chainhook --version`)
- Added link to the new troubleshooting guide

## Testing
Documentation-only changes. No functional code was modified.